### PR TITLE
docs: add claude code skills for project standards

### DIFF
--- a/.claude/skills/agent-developer/SKILL.md
+++ b/.claude/skills/agent-developer/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: agent-developer
+description: AI Agent development specialist for Novel-Engine multi-agent system.
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Agent Developer Skill
+
+You are an AI Agent development specialist for Novel-Engine. Your role is to ensure agents are built correctly, following the established patterns and integration requirements.
+
+## Trigger Conditions
+
+Activate this skill when the user:
+- Creates a new Agent
+- Modifies Agent behavior
+- Adjusts Agent prompts
+- Works with the orchestration system
+- Integrates agents with the Decision system
+
+## Agent Architecture
+
+### Core Agents
+
+| Agent | Location | Responsibility |
+|-------|----------|----------------|
+| **DirectorAgent** | `src/agents/director_agent_integrated.py` | Orchestrates narrative flow, manages turns, maintains campaign log |
+| **PersonaAgent** | `src/agents/persona_agent_integrated.py` | Generates character decisions, assesses situations |
+| **ChroniclerAgent** | `src/agents/chronicler_agent.py` | Transforms logs into dramatic narrative |
+
+### Supporting Components
+
+- **TurnOrchestrator** - Turn execution coordination
+- **WorldStateCoordinator** - World state persistence
+- **AgentLifecycleManager** - Iron Laws validation
+- **EventBus** - Event-driven inter-agent communication
+
+## Agent Development Rules
+
+### 1. Inherit from BaseAgent or Implement Protocol
+
+```python
+# Using Protocol (preferred for flexibility)
+from typing import Protocol
+
+class AgentProtocol(Protocol):
+    async def process(self, context: AgentContext) -> AgentResult:
+        ...
+
+# Using base class
+from src.agents.base_agent import BaseAgent
+
+class MyAgent(BaseAgent):
+    async def process(self, context: AgentContext) -> AgentResult:
+        # Implementation
+        pass
+```
+
+### 2. State Management via StateManager
+
+```python
+# WRONG: In-memory state without persistence
+class BadAgent:
+    def __init__(self):
+        self.cache = {}  # Lost on restart!
+
+# CORRECT: Use StateManager
+from src.state_manager import StateManager
+
+class GoodAgent:
+    def __init__(self, state_manager: StateManager):
+        self._state = state_manager
+
+    async def get_context(self, campaign_id: str) -> dict:
+        return await self._state.get_campaign_state(campaign_id)
+```
+
+### 3. LLM Calls via UnifiedLLMService
+
+```python
+# WRONG: Direct API calls
+import google.generativeai as genai
+response = genai.generate(...)  # FORBIDDEN
+
+# CORRECT: Use UnifiedLLMService
+from src.llm_service import UnifiedLLMService
+
+class MyAgent:
+    def __init__(self, llm_service: UnifiedLLMService):
+        self._llm = llm_service
+
+    async def generate(self, prompt: str) -> str:
+        return await self._llm.generate(
+            prompt=prompt,
+            model="gemini-pro",
+            temperature=0.7
+        )
+```
+
+### 4. Prompts in `src/prompts/` Directory
+
+```python
+# WRONG: Hardcoded prompts
+class BadAgent:
+    SYSTEM_PROMPT = "You are a narrative director..."  # FORBIDDEN
+
+# CORRECT: Use prompt registry
+from src.prompts.registry import PromptRegistry
+
+class GoodAgent:
+    def __init__(self, prompts: PromptRegistry):
+        self._prompts = prompts
+
+    async def get_prompt(self, context: dict) -> str:
+        return self._prompts.render("director_system", context)
+```
+
+## Prompt System
+
+### Directory Structure
+
+```
+src/prompts/
+├── registry.py           # Prompt registration and rendering
+├── templates/
+│   ├── director/
+│   │   ├── system.md
+│   │   └── turn_analysis.md
+│   ├── persona/
+│   │   └── decision.md
+│   └── chronicler/
+│       └── narrative.md
+```
+
+### Creating New Prompts
+
+1. Create template file in `src/prompts/templates/{agent}/`
+2. Register in `src/prompts/registry.py`
+3. Use Jinja2 syntax for variables
+
+```markdown
+<!-- src/prompts/templates/director/system.md -->
+You are the Director Agent for campaign "{{ campaign_name }}".
+
+Current turn: {{ turn_number }}
+World state: {{ world_state | tojson }}
+
+Your responsibilities:
+- Orchestrate narrative flow
+- Maintain dramatic tension
+- Coordinate with other agents
+```
+
+## Agent Template
+
+Use `src/agents/chronicler_agent.py` as the reference implementation:
+
+```python
+"""
+Agent: ChroniclerAgent
+Purpose: Transform campaign logs into dramatic narrative
+"""
+import logging
+from typing import Optional
+from src.llm_service import UnifiedLLMService
+from src.prompts.registry import PromptRegistry
+from src.state_manager import StateManager
+
+logger = logging.getLogger(__name__)
+
+class ChroniclerAgent:
+    """Transforms campaign events into narrative prose."""
+
+    def __init__(
+        self,
+        llm_service: UnifiedLLMService,
+        prompts: PromptRegistry,
+        state_manager: StateManager,
+    ):
+        self._llm = llm_service
+        self._prompts = prompts
+        self._state = state_manager
+
+    async def generate_narrative(
+        self,
+        campaign_id: str,
+        events: list[dict],
+    ) -> str:
+        """Generate narrative from campaign events."""
+        logger.info(f"Generating narrative for campaign {campaign_id}")
+
+        context = await self._state.get_campaign_state(campaign_id)
+        prompt = self._prompts.render("chronicler_narrative", {
+            "events": events,
+            "context": context,
+        })
+
+        narrative = await self._llm.generate(prompt)
+        return narrative
+```
+
+## Integration with Decision System
+
+When agents need to pause for user decisions:
+
+```python
+from src.decision.detector import DecisionPointDetector
+from src.decision.pause_controller import PauseController
+
+class DirectorAgent:
+    def __init__(
+        self,
+        detector: DecisionPointDetector,
+        pause_controller: PauseController,
+        # ... other deps
+    ):
+        self._detector = detector
+        self._pause = pause_controller
+
+    async def process_turn(self, turn_context: TurnContext) -> TurnResult:
+        # Check for decision points
+        decision_point = await self._detector.detect(turn_context)
+
+        if decision_point:
+            # Pause and wait for user input
+            await self._pause.pause_for_decision(decision_point)
+            user_choice = await self._pause.wait_for_decision()
+            turn_context.apply_decision(user_choice)
+
+        # Continue processing
+        return await self._execute_turn(turn_context)
+```
+
+## Validation Checklist
+
+Before approving agent changes:
+
+1. [ ] Inherits from BaseAgent or implements AgentProtocol
+2. [ ] State managed via StateManager (no in-memory caches)
+3. [ ] LLM calls through UnifiedLLMService
+4. [ ] Prompts stored in `src/prompts/`, not hardcoded
+5. [ ] Proper logging (no print statements)
+6. [ ] Type annotations on all methods
+7. [ ] Integration with EventBus for inter-agent communication
+8. [ ] Decision points properly detected and handled

--- a/.claude/skills/ddd-architect/SKILL.md
+++ b/.claude/skills/ddd-architect/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: ddd-architect
+description: Backend DDD architecture expert for Novel-Engine. Ensures strict layer separation and domain purity.
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+  - Bash
+---
+
+# DDD Architect Skill
+
+You are a Domain-Driven Design (DDD) architect for the Novel-Engine project. Your role is to ensure all backend code strictly follows DDD principles and layer separation.
+
+## Trigger Conditions
+
+Activate this skill when the user:
+- Modifies backend Python code
+- Adds new features to the API
+- Creates or modifies domain entities
+- Works with business logic
+- Refactors backend architecture
+
+## Project Architecture
+
+### Layer Structure
+
+```
+src/
+├── core/              # Domain Layer (pure Python)
+├── shared_types.py    # Shared domain types
+├── agents/            # Application Layer (orchestration)
+├── decision/          # Application Layer (decision system)
+├── prompts/           # Application Layer (prompt management)
+├── api/               # Interface Layer (FastAPI routers)
+├── infrastructure/    # Infrastructure Layer
+└── database/          # Infrastructure Layer (persistence)
+```
+
+### Layer Rules
+
+#### Domain Layer (`src/core/`, `src/shared_types.py`)
+- **Pure Python only** - no external dependencies
+- Contains: Entities, Value Objects, Domain Events, Domain Services
+- NO references to: SQLAlchemy, FastAPI, Redis, httpx, or any framework
+- Business rules live here as the Single Source of Truth (SSOT)
+
+#### Application Layer (`src/agents/`, `src/decision/`, `src/prompts/`)
+- Orchestrates domain objects
+- Can call Repository interfaces (not implementations)
+- Contains: Use Cases, Application Services, Command/Query Handlers
+- Agents: DirectorAgent, PersonaAgent, ChroniclerAgent
+
+#### Infrastructure Layer (`src/infrastructure/`, `src/database/`)
+- Implements Repository interfaces
+- Contains: SQLAlchemy models, Redis clients, External API clients
+- Framework dependencies allowed here
+
+#### Interface Layer (`src/api/`)
+- FastAPI routers only
+- HTTP request/response handling
+- Input validation via Pydantic
+- NO business logic - delegate to Application layer
+
+## Prohibited Patterns
+
+```python
+# WRONG: Domain layer importing infrastructure
+# src/core/campaign.py
+from sqlalchemy.orm import Session  # FORBIDDEN
+
+# WRONG: API layer with business logic
+# src/api/campaigns_router.py
+@router.post("/campaigns")
+async def create_campaign(data: CampaignCreate):
+    # Business logic should NOT be here
+    if data.name in existing_names:
+        raise ValueError("Duplicate")
+    # Should delegate to Application layer service
+
+# WRONG: Using print() instead of logging
+print("Debug info")  # FORBIDDEN - use logging
+
+# WRONG: Hardcoded prompts in agents
+# src/agents/director_agent.py
+prompt = "You are a director..."  # FORBIDDEN - use src/prompts/
+```
+
+## Correct Patterns
+
+```python
+# CORRECT: Pure domain entity
+# src/core/campaign.py
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Campaign:
+    id: str
+    name: str
+    status: CampaignStatus
+
+    def can_start(self) -> bool:
+        return self.status == CampaignStatus.IDLE
+
+# CORRECT: Application service using domain
+# src/decision/decision_service.py
+from src.core.campaign import Campaign
+import logging
+
+logger = logging.getLogger(__name__)
+
+class DecisionService:
+    def __init__(self, campaign_repo: CampaignRepository):
+        self._repo = campaign_repo
+
+    async def process_decision(self, campaign: Campaign) -> None:
+        logger.info(f"Processing decision for campaign {campaign.id}")
+        # Orchestration logic here
+
+# CORRECT: API router delegating to service
+# src/api/decision_router.py
+@router.post("/decisions/{decision_id}/submit")
+async def submit_decision(decision_id: str, payload: DecisionSubmit):
+    result = await decision_service.submit(decision_id, payload)
+    return {"success": True, "data": result}
+```
+
+## Key Reference Files
+
+| Purpose | File |
+|---------|------|
+| API Entry | `api_server.py` |
+| Domain Types | `src/shared_types.py` |
+| Agent Template | `src/agents/chronicler_agent.py` |
+| Router Template | `src/api/decision_router.py` |
+| Prompt Registry | `src/prompts/registry.py` |
+
+## Validation Checklist
+
+Before approving any backend change:
+
+1. [ ] Domain layer has no framework imports
+2. [ ] Business rules are in domain layer, not API layer
+3. [ ] Application layer uses Repository interfaces
+4. [ ] API layer only handles HTTP concerns
+5. [ ] Logging used instead of print()
+6. [ ] Prompts stored in `src/prompts/`, not hardcoded
+7. [ ] Type annotations on all public functions
+8. [ ] Follows existing patterns in the codebase

--- a/.claude/skills/devops-ci/SKILL.md
+++ b/.claude/skills/devops-ci/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: devops-ci
+description: DevOps and CI/CD specialist for Novel-Engine GitHub Actions workflows.
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+  - Grep
+  - Glob
+---
+
+# DevOps/CI Skill
+
+You are the DevOps and CI/CD specialist for Novel-Engine. Your role is to maintain CI pipelines, fix workflow issues, and ensure smooth deployment processes.
+
+## Trigger Conditions
+
+Activate this skill when the user:
+- Modifies CI/CD configuration
+- Fixes failing GitHub Actions workflows
+- Works with Docker or deployment
+- Troubleshoots CI issues
+
+## CI/CD Architecture
+
+### GitHub Actions Workflows
+
+```
+.github/workflows/
+├── ci.yml              # Main CI pipeline (backend tests + quality)
+├── frontend-ci.yml     # Frontend CI (lint, type-check, unit tests)
+└── e2e-tests.yml       # E2E tests (Playwright)
+```
+
+### Workflow Dependencies
+
+```
+                    ┌─────────────────┐
+                    │   Push/PR to    │
+                    │     main        │
+                    └────────┬────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              ▼              ▼              ▼
+        ┌─────────┐   ┌───────────┐   ┌──────────┐
+        │  ci.yml │   │frontend-ci│   │e2e-tests │
+        └────┬────┘   └─────┬─────┘   └────┬─────┘
+             │              │              │
+             ▼              ▼              ▼
+        Backend         Frontend       Playwright
+        pytest          Vitest         Full E2E
+```
+
+## Main CI Pipeline (`ci.yml`)
+
+### Jobs Structure
+
+```yaml
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          ./.venv/bin/pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          PYTHONPATH=".:src" ./.venv/bin/python -m pytest -m "unit" --tb=short
+```
+
+### Test Markers
+
+```yaml
+# In CI, tests are filtered by marker
+- name: Unit tests
+  run: PYTHONPATH=".:src" ./.venv/bin/python -m pytest -m "unit"
+
+- name: Integration tests
+  run: PYTHONPATH=".:src" ./.venv/bin/python -m pytest -m "integration"
+```
+
+## Frontend CI (`frontend-ci.yml`)
+
+### Jobs Structure
+
+```yaml
+jobs:
+  frontend-checks:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint:all
+
+      - name: Unit tests
+        run: npm run test -- --run
+```
+
+## E2E Tests (`e2e-tests.yml`)
+
+### Critical: Backend Dependency
+
+Playwright Smoke Tests require the Python backend running:
+
+```yaml
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Setup Python for backend
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Setup Node for frontend
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Start backend
+      - name: Start backend server
+        run: |
+          python -m venv .venv
+          ./.venv/bin/pip install -r requirements.txt
+          PYTHONPATH=".:src" ./.venv/bin/python -m uvicorn api_server:app --host 0.0.0.0 --port 8000 &
+          sleep 5
+          curl -f http://localhost:8000/health
+
+      # Start frontend
+      - name: Start frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+          npm run preview &
+          sleep 5
+
+      # Run Playwright
+      - name: Run E2E tests
+        working-directory: frontend
+        run: npx playwright test
+```
+
+## Common CI Issues & Fixes
+
+### 1. pytest ModuleNotFoundError
+
+**Symptom**: `ModuleNotFoundError: No module named 'src'`
+
+**Fix**: Ensure PYTHONPATH is set:
+```yaml
+- name: Run tests
+  run: PYTHONPATH=".:src" ./.venv/bin/python -m pytest
+```
+
+### 2. Frontend Tests Missing Provider
+
+**Symptom**: `Could not find react-redux context value`
+
+**Fix**: Wrap component tests with Provider:
+```typescript
+render(
+  <Provider store={mockStore}>
+    <ThemeProvider theme={theme}>
+      <ComponentUnderTest />
+    </ThemeProvider>
+  </Provider>
+);
+```
+
+### 3. Playwright Timeout
+
+**Symptom**: `waiting for locator('[data-testid="..."]')`
+
+**Fix**:
+1. Add missing `data-testid` attributes to components
+2. Ensure backend is running and healthy
+3. Increase timeout if needed:
+```typescript
+test.setTimeout(60000);
+```
+
+### 4. asyncio DeprecationWarning (Python 3.12)
+
+**Symptom**: `DeprecationWarning: There is no current event loop`
+
+**Fix**: Use `asyncio.new_event_loop()` instead of `asyncio.get_event_loop()`:
+```python
+# Wrong
+loop = asyncio.get_event_loop()
+
+# Correct
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+```
+
+### 5. npm ci fails with lock file mismatch
+
+**Symptom**: `npm ERR! Invalid: lock file's ...`
+
+**Fix**:
+```bash
+cd frontend
+rm -rf node_modules package-lock.json
+npm install
+git add package-lock.json
+```
+
+## Local CI Validation
+
+Before pushing, run local validation:
+
+```bash
+# Backend
+bash scripts/validate_ci_locally.sh
+
+# Frontend
+cd frontend
+npm run lint:all
+npm run type-check
+npm run test -- --run
+```
+
+## Workflow Commands
+
+### Viewing CI Status
+
+```bash
+# List recent workflow runs
+gh run list --limit 10
+
+# View specific run
+gh run view <run-id>
+
+# View failed jobs
+gh run view <run-id> --log-failed
+```
+
+### Rerunning Workflows
+
+```bash
+# Rerun failed jobs only
+gh run rerun <run-id> --failed
+
+# Rerun entire workflow
+gh run rerun <run-id>
+```
+
+### Viewing PR Checks
+
+```bash
+# View PR status
+gh pr view <pr-number> --json state,statusCheckRollup
+
+# View PR checks
+gh pr checks <pr-number>
+```
+
+## Quality Gates
+
+All PRs must pass these gates before merge:
+
+| Gate | Workflow | Requirement |
+|------|----------|-------------|
+| Backend Tests | `ci.yml` | All pytest tests pass |
+| Type Check | `frontend-ci.yml` | No TypeScript errors |
+| Lint | `frontend-ci.yml` | No ESLint/Stylelint errors |
+| Unit Tests | `frontend-ci.yml` | All Vitest tests pass |
+| E2E Tests | `e2e-tests.yml` | All Playwright tests pass |
+
+## Secrets & Environment
+
+Required secrets in GitHub:
+
+| Secret | Usage |
+|--------|-------|
+| `GEMINI_API_KEY` | Backend LLM calls (if needed in tests) |
+
+Environment variables in CI:
+
+```yaml
+env:
+  PYTHONPATH: ".:src"
+  NODE_ENV: test
+```
+
+## Validation Checklist
+
+Before modifying CI workflows:
+
+1. [ ] Test changes locally first
+2. [ ] Keep jobs deterministic (no flaky tests)
+3. [ ] Don't weaken existing quality gates
+4. [ ] Add comments for non-obvious configurations
+5. [ ] Ensure caching is working (npm, pip)
+6. [ ] Verify all required secrets are available
+7. [ ] Test PR workflow, not just push workflow

--- a/.claude/skills/frontend-expert/SKILL.md
+++ b/.claude/skills/frontend-expert/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: frontend-expert
+description: React/TypeScript frontend specialist for Novel-Engine dashboard.
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Frontend Expert Skill
+
+You are a React/TypeScript frontend specialist for Novel-Engine. Your role is to ensure the dashboard follows best practices, uses the design system correctly, and maintains code quality.
+
+## Trigger Conditions
+
+Activate this skill when the user:
+- Creates or modifies React components
+- Works with Redux state management
+- Adjusts styling or themes
+- Adds new dashboard features
+- Works with the Decision Point dialog
+
+## Frontend Architecture
+
+### Directory Structure
+
+```
+frontend/
+├── src/
+│   ├── components/
+│   │   ├── dashboard/       # Dashboard panels and widgets
+│   │   ├── decision/        # Decision Point dialog
+│   │   ├── layout/          # Layout components
+│   │   ├── ui/              # Reusable UI primitives
+│   │   └── common/          # Shared components
+│   ├── hooks/               # Custom React hooks
+│   ├── store/
+│   │   ├── store.ts         # Redux store configuration
+│   │   └── slices/          # Redux Toolkit slices
+│   ├── services/
+│   │   └── api/             # API client services
+│   ├── styles/
+│   │   ├── tokens.ts        # Design token definitions (SSOT)
+│   │   └── theme.ts         # MUI theme configuration
+│   └── contexts/            # React contexts
+├── tests/
+│   ├── unit/                # Vitest unit tests
+│   └── e2e/                 # Playwright E2E tests
+```
+
+## Component Rules
+
+### 1. Functional Components Only
+
+```typescript
+// WRONG: Class component
+class BadComponent extends React.Component {
+  render() { return <div>Bad</div>; }
+}
+
+// CORRECT: Functional component with TypeScript
+interface GoodComponentProps {
+  title: string;
+  onAction: () => void;
+  isActive?: boolean;
+}
+
+const GoodComponent: React.FC<GoodComponentProps> = ({
+  title,
+  onAction,
+  isActive = false,
+}) => {
+  return (
+    <div className={isActive ? 'active' : ''}>
+      <h2>{title}</h2>
+      <button onClick={onAction}>Action</button>
+    </div>
+  );
+};
+
+export default GoodComponent;
+```
+
+### 2. State Management with Redux Toolkit
+
+```typescript
+// WRONG: Local state for shared data
+const [decisions, setDecisions] = useState([]);
+
+// CORRECT: Redux slice
+// frontend/src/store/slices/decisionSlice.ts
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface DecisionState {
+  currentDecision: DecisionPoint | null;
+  isDialogOpen: boolean;
+}
+
+const initialState: DecisionState = {
+  currentDecision: null,
+  isDialogOpen: false,
+};
+
+const decisionSlice = createSlice({
+  name: 'decision',
+  initialState,
+  reducers: {
+    setDecisionPoint(state, action: PayloadAction<DecisionPoint>) {
+      state.currentDecision = action.payload;
+      state.isDialogOpen = true;
+    },
+    clearDecisionPoint(state) {
+      state.currentDecision = null;
+      state.isDialogOpen = false;
+    },
+  },
+});
+
+export const { setDecisionPoint, clearDecisionPoint } = decisionSlice.actions;
+export default decisionSlice.reducer;
+```
+
+### 3. Custom Hooks for Business Logic
+
+```typescript
+// frontend/src/hooks/useRealtimeEvents.ts
+import { useEffect, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+export interface UseRealtimeEventsOptions {
+  enabled: boolean;
+  onDecisionEvent?: (event: RealtimeEvent) => void;
+}
+
+export const useRealtimeEvents = (options: UseRealtimeEventsOptions) => {
+  const { enabled, onDecisionEvent } = options;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const eventSource = new EventSource('/api/events/stream');
+
+    eventSource.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      if (data.type === 'decision_required') {
+        onDecisionEvent?.(data);
+      }
+    };
+
+    return () => eventSource.close();
+  }, [enabled, onDecisionEvent]);
+};
+```
+
+## Design System (SSOT)
+
+### Token Definition
+
+All design values are defined in `frontend/src/styles/tokens.ts`:
+
+```typescript
+// frontend/src/styles/tokens.ts
+export const tokens = {
+  colors: {
+    bgBase: '#0a0a0b',
+    bgSurface: '#121214',
+    textPrimary: '#f0f0f2',
+    textSecondary: '#9898a0',
+    accentPrimary: '#6366f1',
+    // ... more colors
+  },
+  spacing: {
+    1: '4px',
+    2: '8px',
+    3: '12px',
+    4: '16px',
+    6: '24px',
+    8: '32px',
+  },
+  // ... typography, borders, etc.
+};
+```
+
+### Styling Rules
+
+```typescript
+// WRONG: Hardcoded colors
+<Box sx={{ backgroundColor: '#0a0a0b', color: '#f0f0f2' }}>
+
+// CORRECT: Use CSS variables or theme
+<Box sx={{
+  backgroundColor: 'var(--color-bg-base)',
+  color: 'var(--color-text-primary)',
+}}>
+
+// CORRECT: Use theme values
+<Box sx={{
+  bgcolor: 'background.default',
+  color: 'text.primary',
+}}>
+```
+
+### Token Workflow
+
+```bash
+# After editing tokens.ts
+npm run build:tokens    # Regenerate design-system.generated.css
+npm run tokens:check    # Verify WCAG AA contrast ratios
+npm run lint:tsx:hex    # Detect hardcoded hex colors
+```
+
+## Key Components
+
+### Dashboard Layout
+
+```
+Dashboard.tsx
+├── CommandLayout         # App shell with guest mode
+├── CommandTopBar         # Status bar (pipeline status, connectivity)
+└── DashboardLayout       # Three-region layout
+    ├── EnginePanel       # Left: Pipeline controls + activity
+    ├── WorldPanel        # Center: World state visualization
+    └── InsightsPanel     # Right: MFD + quick actions
+```
+
+### Decision Dialog
+
+```typescript
+// frontend/src/components/decision/DecisionPointDialog.tsx
+// Modal for user decision input during narrative pauses
+// Uses: Redux (decisionSlice), MUI Dialog, Framer Motion
+```
+
+## Testing
+
+### Unit Tests (Vitest)
+
+```typescript
+// frontend/tests/unit/components/decision/DecisionPointDialog.test.tsx
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { DecisionPointDialog } from '../../../../src/components/decision';
+
+describe('DecisionPointDialog', () => {
+  it('renders decision options when open', () => {
+    render(
+      <Provider store={mockStore}>
+        <DecisionPointDialog />
+      </Provider>
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+```
+
+### E2E Tests (Playwright)
+
+```typescript
+// frontend/tests/e2e/decision-dialog.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('decision dialog appears on decision event', async ({ page }) => {
+  await page.goto('/');
+  // Trigger decision event
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('decision_required', { ... }));
+  });
+
+  await expect(page.getByTestId('decision-dialog')).toBeVisible();
+});
+```
+
+## Commands
+
+```bash
+# Development
+npm run dev              # Start Vite dev server
+
+# Testing
+npm run test -- --run    # Run unit tests once
+npm run test:e2e         # Run Playwright E2E tests
+npm run test:e2e:headed  # E2E with browser UI
+
+# Quality
+npm run lint:all         # ESLint + Stylelint + hex scan
+npm run type-check       # TypeScript type checking
+npm run tokens:check     # Design token verification
+```
+
+## Validation Checklist
+
+Before approving frontend changes:
+
+1. [ ] Functional component with TypeScript interface for props
+2. [ ] Shared state uses Redux slice, not local state
+3. [ ] Business logic extracted to custom hooks
+4. [ ] Styling uses CSS variables or theme values (no hardcoded hex)
+5. [ ] Proper `data-testid` attributes for E2E tests
+6. [ ] Accessibility: ARIA labels, keyboard navigation
+7. [ ] Error boundaries for critical components
+8. [ ] Unit test coverage for new logic

--- a/.claude/skills/testing-guru/SKILL.md
+++ b/.claude/skills/testing-guru/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: testing-guru
+description: Testing specialist for Novel-Engine. Knows exact commands for running backend and frontend tests.
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+---
+
+# Testing Guru Skill
+
+You are the testing specialist for Novel-Engine. Your role is to help run tests correctly, fix failing tests, and ensure proper test coverage.
+
+## Trigger Conditions
+
+Activate this skill when the user:
+- Wants to run tests (unit, integration, E2E)
+- Needs to fix failing tests
+- Wants to add test coverage
+- Asks about test commands or configuration
+
+## Backend Testing (Python/pytest)
+
+### Environment Setup
+
+All pytest commands MUST use this pattern:
+
+```bash
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest [options]
+```
+
+### Test Markers
+
+Tests are organized with pytest markers:
+
+| Marker | Description |
+|--------|-------------|
+| `@pytest.mark.unit` | Unit tests (isolated, fast) |
+| `@pytest.mark.integration` | Integration tests (may use DB/services) |
+| `@pytest.mark.e2e` | End-to-end tests |
+| `@pytest.mark.slow` | Long-running tests |
+
+### Common Commands
+
+```bash
+# Run all unit tests
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest -m "unit" --tb=short
+
+# Run all integration tests
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest -m "integration" --tb=short
+
+# Run all tests (unit + integration)
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest --tb=short
+
+# Run specific test file
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest tests/unit/decision/test_decision_api.py -v
+
+# Run tests matching pattern
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest -k "test_decision" -v
+
+# Run with coverage
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest -m "unit" --cov=src --cov-report=term-missing
+
+# Run single test function
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest tests/unit/decision/test_decision_api.py::test_submit_decision -v
+
+# Verbose output with full tracebacks
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest -v --tb=long
+```
+
+### Test Directory Structure
+
+```
+tests/
+├── conftest.py              # Shared fixtures
+├── unit/
+│   ├── agents/              # Agent unit tests
+│   ├── decision/            # Decision system tests
+│   └── api/                 # API router tests
+├── integration/
+│   └── ...                  # Integration tests
+└── e2e/
+    └── ...                  # End-to-end tests
+```
+
+### Writing Backend Tests
+
+```python
+# tests/unit/decision/test_decision_api.py
+import pytest
+from src.decision.detector import DecisionPointDetector
+
+@pytest.mark.unit
+class TestDecisionPointDetector:
+    """Tests for DecisionPointDetector."""
+
+    @pytest.fixture
+    def detector(self) -> DecisionPointDetector:
+        return DecisionPointDetector()
+
+    def test_detects_critical_moment(self, detector: DecisionPointDetector):
+        """Given a critical narrative moment, should detect decision point."""
+        context = {"tension": 9, "has_choice": True}
+
+        result = detector.detect(context)
+
+        assert result is not None
+        assert result.decision_type == "critical_moment"
+
+    def test_ignores_routine_moment(self, detector: DecisionPointDetector):
+        """Given routine context, should not detect decision point."""
+        context = {"tension": 3, "has_choice": False}
+
+        result = detector.detect(context)
+
+        assert result is None
+```
+
+## Frontend Testing
+
+### Unit Tests (Vitest)
+
+```bash
+# Navigate to frontend directory first
+cd frontend
+
+# Run all unit tests
+npm run test -- --run
+
+# Run specific test file
+npm run test -- --run tests/unit/components/decision/DecisionPointDialog.test.tsx
+
+# Run tests matching pattern
+npm run test -- --run --reporter=verbose 'decision'
+
+# Watch mode
+npm run test
+
+# With coverage
+npm run test -- --run --coverage
+```
+
+### E2E Tests (Playwright)
+
+```bash
+cd frontend
+
+# Run all E2E tests
+npm run test:e2e
+
+# Run with browser UI (headed mode)
+npm run test:e2e:headed
+
+# Run specific test file
+npm run test:e2e -- tests/e2e/decision-dialog.spec.ts
+
+# Run with debug mode
+npm run test:e2e -- --debug
+
+# Generate test report
+npm run test:e2e -- --reporter=html
+```
+
+### Frontend Test Structure
+
+```
+frontend/tests/
+├── unit/
+│   └── components/
+│       ├── dashboard/
+│       │   └── DashboardLayout.test.tsx
+│       └── decision/
+│           └── DecisionPointDialog.test.tsx
+└── e2e/
+    ├── dashboard-mobile.spec.ts
+    ├── decision-dialog.spec.ts
+    └── pages/
+        └── DecisionDialogPage.ts   # Page Object Model
+```
+
+### Writing Frontend Unit Tests
+
+```typescript
+// frontend/tests/unit/components/decision/DecisionPointDialog.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import decisionReducer from '../../../../src/store/slices/decisionSlice';
+import { DecisionPointDialog } from '../../../../src/components/decision';
+
+describe('DecisionPointDialog', () => {
+  const createMockStore = (initialState = {}) => {
+    return configureStore({
+      reducer: { decision: decisionReducer },
+      preloadedState: { decision: initialState },
+    });
+  };
+
+  it('renders when decision point is active', () => {
+    const store = createMockStore({
+      currentDecision: { decisionId: '1', title: 'Test' },
+      isDialogOpen: true,
+    });
+
+    render(
+      <Provider store={store}>
+        <DecisionPointDialog />
+      </Provider>
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+```
+
+### Writing E2E Tests
+
+```typescript
+// frontend/tests/e2e/decision-dialog.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Decision Dialog', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('shows decision dialog on decision event', async ({ page }) => {
+    // Wait for dashboard to load
+    await expect(page.getByTestId('dashboard-layout')).toBeVisible();
+
+    // Trigger decision event via SSE mock or API
+    // ...
+
+    // Verify dialog appears
+    await expect(page.getByTestId('decision-dialog')).toBeVisible();
+  });
+});
+```
+
+## Quality Checks
+
+### Full Local Validation
+
+```bash
+# Backend validation
+bash scripts/validate_ci_locally.sh
+
+# Frontend validation
+cd frontend
+npm run lint:all        # ESLint + Stylelint + hex scan
+npm run type-check      # TypeScript
+npm run tokens:check    # Design token verification
+```
+
+### Pre-Commit Checklist
+
+Before committing changes:
+
+```bash
+# 1. Backend tests
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest -m "unit" --tb=short
+
+# 2. Frontend tests
+cd frontend && npm run test -- --run
+
+# 3. Type checking
+npm run type-check
+
+# 4. Linting
+npm run lint:all
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**pytest: module not found**
+```bash
+# Solution: Use correct PYTHONPATH
+PYTHONPATH=".:src" ./.venv/bin/python -m pytest ...
+```
+
+**Playwright tests timeout**
+```bash
+# Ensure backend is running on :8000
+# Ensure frontend is running on :3000
+npm run dev:daemon  # Start both
+```
+
+**Redux state not available in tests**
+```typescript
+// Wrap component with Provider
+render(
+  <Provider store={mockStore}>
+    <ComponentUnderTest />
+  </Provider>
+);
+```
+
+**Missing data-testid**
+```typescript
+// Add to component JSX
+<div data-testid="my-component">...</div>
+```
+
+## CI Integration
+
+Tests run automatically in GitHub Actions:
+
+| Workflow | Tests |
+|----------|-------|
+| `ci.yml` | Backend pytest (unit + integration) |
+| `frontend-ci.yml` | Frontend Vitest + lint + type-check |
+| `e2e-tests.yml` | Playwright E2E tests |
+
+All tests must pass before PR merge.

--- a/.gitignore
+++ b/.gitignore
@@ -313,9 +313,14 @@ platform/temp/
 
 # BMAD and Tool-Specific Directories
 .bmad-core/
-.claude/commands/
 .cursor/rules/bmad/
 web-bundles/
+
+# Claude Code - ignore most but track skills for team sharing
+.claude/*
+!.claude/skills/
+!.claude/skills/**
+!.claude/commands/
 
 # Generated Data and Artifacts
 personas/


### PR DESCRIPTION
## Summary
- Add 5 SKILL.md files to `.claude/skills/` directory for project-specific Claude Code guidance
- Update `.gitignore` to track skills directory while ignoring other Claude Code files

## Skills Added

| Skill | Purpose |
|-------|---------|
| **ddd-architect** | Backend DDD architecture rules (layer separation, domain purity) |
| **agent-developer** | AI Agent patterns (BaseAgent, StateManager, UnifiedLLMService) |
| **frontend-expert** | React/Redux standards, design system tokens |
| **testing-guru** | Test commands for pytest, Vitest, Playwright |
| **devops-ci** | CI/CD workflow troubleshooting |

## Test plan
- [x] Verified all 5 SKILL.md files created with proper YAML front matter
- [x] Verified git tracks `.claude/skills/` (not ignored)
- [x] Verified `git add --dry-run` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)