### PR TITLE
OpenSpec: long-term refactor proposal set

### DIFF
--- a/openspec/changes/add-filesystem-guest-workspaces/design.md
+++ b/openspec/changes/add-filesystem-guest-workspaces/design.md
@@ -1,0 +1,32 @@
+# Design: Filesystem Guest Workspaces
+
+## Goals
+- Guest-first: no login required for core functionality.
+- Durable: atomic writes, crash safety, recoverable state.
+- Isolated: a session cannot read/write another session’s workspace.
+- Inspectable: files are human-readable where feasible; include a manifest and version.
+
+## Workspace Identity
+- Workspace ID is generated server-side and stored in a cookie (or equivalent first-party storage).
+- The backend scopes all operations to the workspace resolved from the request.
+
+## On-Disk Layout (proposed)
+```
+data/workspaces/<workspace_id>/
+  manifest.json            # schemaVersion, createdAt, lastAccessedAt
+  characters/
+    <character_id>.json
+  runs/
+    <run_id>.json
+  narratives/
+    <narrative_id>.json
+  exports/                 # optional staging
+```
+
+## Atomic Writes
+- Writes MUST be atomic (write to temp file, fsync, rename).
+- Corruption recovery MUST prefer last-known-good files and surface a clear error when recovery is impossible.
+
+## Lifecycle
+- Guest workspaces can expire after a configurable TTL, but export/import is always available before cleanup.
+

--- a/openspec/changes/add-filesystem-guest-workspaces/proposal.md
+++ b/openspec/changes/add-filesystem-guest-workspaces/proposal.md
@@ -1,0 +1,25 @@
+# Proposal: Add Guest Workspaces Backed by the Filesystem
+
+## Why
+- The product already supports a “guest/demo” entry in the frontend, but persistence is not formalized: data layout, session boundaries, and durability guarantees are implicit.
+- A filesystem-backed workspace is the simplest long-term persistence layer for this project (no DB requirement) while still enabling correctness: isolation, atomic writes, schema versioning, export/import.
+- “Real usable” frontend flows require reliable persistence across refreshes and sessions, especially in guest mode.
+
+## What Changes
+1. **Session → workspace mapping**
+   - A guest session creates (or resumes) a filesystem workspace, and all user-created artifacts (characters, runs, narratives) are scoped to that workspace.
+2. **Filesystem store with durability guarantees**
+   - Define an on-disk layout, schema versioning, atomic writes, and recovery behavior.
+3. **Workspace lifecycle**
+   - Add lifecycle rules for guests (TTL/cleanup) and explicit export/import for portability.
+4. **Character-service alignment**
+   - Treat “guest session” as a valid authenticated session boundary for character CRUD and simulations.
+
+## Impact
+- Establishes a durable persistence foundation without introducing a database.
+- Provides a clear contract for backend and frontend to share (workspace identity + isolation).
+
+## Dependencies
+- Should follow `standardize-api-surface`.
+- Benefits from `refactor-backend-api-platform` so persistence is behind interfaces.
+

--- a/openspec/changes/add-filesystem-guest-workspaces/specs/character-service/spec.md
+++ b/openspec/changes/add-filesystem-guest-workspaces/specs/character-service/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Authenticated Character Management
+- **CHANGE**: “authenticated” requests MAY be satisfied by a first-party guest session. Character CRUD MUST be scoped to the current session/workspace boundary.
+
+#### Scenario: Guest session can create a character
+- **GIVEN** a guest session is established
+- **WHEN** the session POSTs to `/api/characters` with a valid payload
+- **THEN** the API persists the character inside the guest workspace and returns 201 with the created record.
+
+#### Scenario: Guest session lists only its own characters
+- **GIVEN** two guest sessions exist and each has created characters
+- **WHEN** one session GETs `/api/characters`
+- **THEN** it receives only the characters owned by that session/workspace (plus any documented defaults), and never sees the other session’s characters.
+

--- a/openspec/changes/add-filesystem-guest-workspaces/specs/filesystem-workspace-store/spec.md
+++ b/openspec/changes/add-filesystem-guest-workspaces/specs/filesystem-workspace-store/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Workspace isolation
+The system MUST scope all user-created data to a workspace derived from the current session and MUST NOT allow access across workspaces.
+
+#### Scenario: Two guest sessions are isolated
+- **GIVEN** two separate guest sessions exist
+- **WHEN** session A creates a character
+- **THEN** session B does not see that character when listing its characters.
+
+### Requirement: Durable writes on filesystem
+Workspace persistence MUST be stored on the filesystem with atomic write semantics so partial writes do not corrupt data.
+
+#### Scenario: Character write is atomic
+- **WHEN** the backend persists a character record to disk
+- **THEN** the file is written atomically (temp + rename) so an interruption does not leave a partially-written JSON document.
+
+### Requirement: Workspace schema versioning
+Each workspace MUST contain a manifest that records a schema version and supports forward migrations.
+
+#### Scenario: Workspace includes schemaVersion
+- **WHEN** a workspace is created on disk
+- **THEN** it contains a manifest with `schemaVersion` and timestamps that can be used for migrations and diagnostics.
+
+### Requirement: Workspace export and import
+The system MUST support exporting a workspace and importing it into a new session to enable portability.
+
+#### Scenario: Exported workspace can be re-imported
+- **GIVEN** a workspace contains at least one character
+- **WHEN** the user exports and then imports the workspace
+- **THEN** the imported workspace contains the same character data and identifiers (or a documented mapping if IDs are reissued).
+

--- a/openspec/changes/add-filesystem-guest-workspaces/tasks.md
+++ b/openspec/changes/add-filesystem-guest-workspaces/tasks.md
@@ -1,0 +1,20 @@
+## Implementation Tasks
+1. Define workspace contract
+   - [ ] Decide workspace identifier format, TTL policy, and request binding (cookie/header).
+   - [ ] Define the on-disk layout and the manifest/schemaVersion fields.
+
+2. Implement filesystem workspace store
+   - [ ] Introduce store interfaces (workspace, characters, runs) and a filesystem implementation.
+   - [ ] Implement atomic write utilities and safe path handling (prevent traversal).
+   - [ ] Implement list/get/put/delete behavior for characters inside a workspace.
+
+3. Add session bootstrap + lifecycle
+   - [ ] Add an endpoint/middleware to create or resume a guest session and resolve workspace.
+   - [ ] Add TTL cleanup logic (manual command or scheduled job) with safety rails.
+   - [ ] Add export/import for workspace portability (zip or tar).
+
+4. Tests and validation
+   - [ ] Add unit tests for atomic write + path safety.
+   - [ ] Add integration tests for session isolation (two sessions cannot see each other’s characters).
+   - [ ] Run full CI suite and `openspec validate add-filesystem-guest-workspaces --strict`.
+

--- a/openspec/changes/refactor-backend-api-platform/design.md
+++ b/openspec/changes/refactor-backend-api-platform/design.md
@@ -1,0 +1,36 @@
+# Design: Backend API Platform Refactor
+
+## Principles (AI-friendly)
+- **One way to do it**: one canonical app factory, one canonical place to register routers/middleware.
+- **No import side effects**: importing modules should not start servers or mutate global state.
+- **Explicit dependencies**: services depend on interfaces (repositories/stores), wired in the app factory.
+- **Small modules, stable names**: predictable locations for routes, schemas, and services.
+
+## Target Structure (illustrative)
+```
+src/api/
+  app.py                  # create_app()
+  settings.py             # typed settings/env
+  deps.py                 # dependency providers
+  errors.py               # error models + handlers
+  routers/
+    characters.py
+    sessions.py
+    simulations.py
+    events.py
+  services/
+    character_service.py
+    session_service.py
+  stores/
+    character_store.py    # interface
+    filesystem_store.py   # impl (future change)
+```
+
+## Compatibility Strategy
+- Keep existing launch scripts/files as thin wrappers that call `create_app()` until fully migrated.
+- Prefer additive migration: move one router at a time, keep endpoints stable, and prove equivalence via tests.
+
+## Contract Strategy
+- Schemas: Pydantic models are the single source of truth for OpenAPI.
+- Errors: provide a stable error envelope with codes so frontend can handle predictably.
+

--- a/openspec/changes/refactor-backend-api-platform/proposal.md
+++ b/openspec/changes/refactor-backend-api-platform/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: Refactor Backend API Platform (Best-Practice + AI-Friendly)
+
+## Why
+- The backend currently exposes multiple server entrypoints and mixed conventions, making it difficult to reason about “the real app” and increasing the risk of route/config drift.
+- Business/domain logic is often interleaved with routing concerns, which makes testing and refactoring expensive.
+- Long-term roadmap items (guest filesystem workspaces, typed API client, real UI flows, reliable event streaming) require a stable backend platform: app factory, clear module boundaries, consistent errors, and predictable configuration.
+
+## What Changes
+1. **Single canonical FastAPI app factory**
+   - Introduce a `create_app()` entrypoint that registers routers, middleware, exception handlers, and dependencies without import-time side effects.
+2. **Router + service boundaries**
+   - Routes live in `routers/*`, domain operations in `services/*`, and persistence behind repository/store interfaces.
+3. **Consistent contract + errors**
+   - Standardize request/response models and error envelopes across all product endpoints.
+4. **OpenAPI as a contract artifact**
+   - Ensure the OpenAPI schema produced by the canonical app is consistent and suitable for generating a typed frontend client.
+
+## Impact
+- Moves backend code toward a predictable “platform + domains” layout.
+- Enables reliable tests (unit + integration) and reduces cross-file coupling, making future features/refactors safer.
+
+## Dependencies
+- Should follow `standardize-api-surface` (so routes and docs are stabilized before refactor churn).
+- Unblocks `add-filesystem-guest-workspaces` and `refactor-frontend-api-and-ux`.
+
+## Out of Scope
+- Large UI/UX work (handled by frontend proposal).
+- Implementing filesystem workspaces (handled by `add-filesystem-guest-workspaces`).
+

--- a/openspec/changes/refactor-backend-api-platform/specs/backend-api-platform/spec.md
+++ b/openspec/changes/refactor-backend-api-platform/specs/backend-api-platform/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Canonical app factory
+The backend MUST expose a canonical FastAPI app factory (`create_app()`) that can be imported by tests and production runners without triggering side effects.
+
+#### Scenario: Tests can create an app instance
+- **GIVEN** a test suite imports `create_app()`
+- **WHEN** the suite constructs the app and issues requests via a test client
+- **THEN** the app responds without requiring global initialization order or background side effects.
+
+### Requirement: Routes are organized by domain routers
+Product API endpoints MUST be implemented via domain routers (e.g., characters, sessions, simulations, events) registered by the canonical app factory.
+
+#### Scenario: Adding a new endpoint is localized
+- **GIVEN** a new product endpoint is added to the backend
+- **WHEN** a developer implements it
+- **THEN** they add it to a single domain router module and do not need to duplicate logic across multiple server entrypoints.
+
+### Requirement: Standardized error envelope
+All product API endpoints MUST return errors using a standardized, documented error envelope with stable error codes.
+
+#### Scenario: Validation error is normalized
+- **WHEN** a client sends an invalid payload to a product endpoint
+- **THEN** the API returns a 4xx response whose body includes a stable error code and human-readable message suitable for display and logging.
+
+### Requirement: OpenAPI output matches the canonical app
+The OpenAPI schema used for documentation and client generation MUST be produced by the canonical app factory and reflect the real deployed routes.
+
+#### Scenario: OpenAPI can be used for typed client generation
+- **WHEN** the OpenAPI schema is exported from the running app
+- **THEN** it includes accurate routes and request/response shapes for the product API, enabling a generated client to call the API without manual patching.
+

--- a/openspec/changes/refactor-backend-api-platform/tasks.md
+++ b/openspec/changes/refactor-backend-api-platform/tasks.md
@@ -1,0 +1,21 @@
+## Implementation Tasks
+1. Baseline and contracts
+   - [ ] Identify the canonical “product API” endpoints and add/confirm integration tests for them (status codes + payload shape).
+   - [ ] Freeze the current OpenAPI output as a reference artifact for later diffing.
+
+2. Introduce a canonical app factory
+   - [ ] Add `create_app()` that wires routers, middleware, exception handling, and config.
+   - [ ] Ensure importing the app factory has no side effects (no server start, no filesystem writes).
+
+3. Establish module boundaries
+   - [ ] Move one domain at a time into `routers/*` + `services/*` while keeping routes stable.
+   - [ ] Introduce dependency providers for services and stores (DI-friendly).
+
+4. Standardize errors and response models
+   - [ ] Create a consistent error envelope and convert product routes to use it.
+   - [ ] Ensure validation errors are also normalized.
+
+5. Validation gates
+   - [ ] Run full backend tests, frontend tests, and CI-parity scripts.
+   - [ ] Run `openspec validate refactor-backend-api-platform --strict`.
+

--- a/openspec/changes/refactor-frontend-api-and-ux/design.md
+++ b/openspec/changes/refactor-frontend-api-and-ux/design.md
@@ -1,0 +1,26 @@
+# Design: Frontend API SSOT + Usable Flows
+
+## Target State
+- A single API module (`frontend/src/lib/api/*`) owns:
+  - base URL resolution
+  - session bootstrap (guest)
+  - request/response typing
+  - error normalization
+- Feature code uses hooks that compose the SSOT client and expose:
+  - `data` / `isLoading` / `error`
+  - stable query keys
+  - cancellation and retry policies
+
+## UX Flows (guest-first)
+1. Landing (`/`)
+   - “Continue as guest” starts/resumes a guest session.
+2. Workspace/Dashboard (`/dashboard`)
+   - Shows workspace status (guest badge, save indicator).
+   - Lists characters with create/edit/delete.
+3. Run (`/runs/:id` or inline panel)
+   - Starts a simulation and renders the resulting narrative.
+
+## Error Handling
+- All API errors are normalized into a small set of categories (validation, auth/session, network, server).
+- UI renders consistent empty/loading/error patterns with actionable guidance.
+

--- a/openspec/changes/refactor-frontend-api-and-ux/proposal.md
+++ b/openspec/changes/refactor-frontend-api-and-ux/proposal.md
@@ -1,0 +1,21 @@
+# Proposal: Refactor Frontend API Layer + Make the App “Real Usable”
+
+## Why
+- The frontend currently contains multiple overlapping API layers (services + hooks) and mismatched endpoint assumptions, which makes it easy to regress integration when backend contracts change.
+- Some user-facing areas still behave like demos (sample fallbacks, inconsistent error states) rather than a reliable product surface.
+- Long-term refactors need a stable frontend foundation: one API client, predictable data-fetching patterns, and complete guest-first flows.
+
+## What Changes
+1. **Single API client (SSOT)**
+   - Introduce one typed client wrapper used by all hooks/components; standardize base URL, headers, and error handling.
+2. **Guest-first session bootstrap**
+   - Make “start/resume guest session” a first-class part of app initialization so persistence survives refreshes.
+3. **Real usable flows**
+   - Ensure users can: enter as guest, manage characters, run a simulation/story, and reload the page without losing their workspace state.
+4. **UX reliability**
+   - Standardize loading/empty/error states and add actionable messages when backend is unavailable.
+
+## Dependencies
+- Depends on `standardize-api-surface` so frontend endpoints have a stable base.
+- Benefits from `add-filesystem-guest-workspaces` so “usable flows” have durable persistence.
+

--- a/openspec/changes/refactor-frontend-api-and-ux/specs/frontend-workspace-ui/spec.md
+++ b/openspec/changes/refactor-frontend-api-and-ux/specs/frontend-workspace-ui/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Guest-first entry is usable
+The frontend MUST allow a visitor to enter the product as a guest and reach a functional dashboard without requiring credentials.
+
+#### Scenario: Guest enters from landing page
+- **GIVEN** a visitor starts at `/` without an existing session
+- **WHEN** they choose “Continue as guest”
+- **THEN** the app establishes a guest session (or resumes one) and navigates to a usable dashboard view.
+
+### Requirement: Character management uses real API
+The frontend MUST provide character list + create/edit/delete flows backed by the character service API, with consistent loading/empty/error states.
+
+#### Scenario: Create character from UI persists
+- **GIVEN** the user is on the dashboard as a guest
+- **WHEN** they create a character via the UI
+- **THEN** the frontend POSTs to `/api/characters`, shows the created character in the list, and it remains visible after refresh.
+
+### Requirement: Usable story/run flow
+The frontend MUST allow starting a simulation/story run and rendering the resulting narrative, including error handling and retry.
+
+#### Scenario: User starts a run and sees output
+- **GIVEN** at least one character exists in the workspace
+- **WHEN** the user starts a run from the UI
+- **THEN** the UI shows progress/loading feedback and then renders the resulting narrative output on success.
+
+### Requirement: API errors are consistently handled
+API failures MUST be rendered using a consistent error pattern with actionable messaging (retry, offline indicator, or next steps).
+
+#### Scenario: Backend is unavailable
+- **WHEN** the backend API cannot be reached
+- **THEN** the UI shows a clear error state (not demo/sample data) and provides a retry action and troubleshooting hint.
+

--- a/openspec/changes/refactor-frontend-api-and-ux/tasks.md
+++ b/openspec/changes/refactor-frontend-api-and-ux/tasks.md
@@ -1,0 +1,19 @@
+## Implementation Tasks
+1. Establish API SSOT client
+   - [ ] Add a single API client module and migrate existing services/hooks to use it (no duplicated axios wrappers).
+   - [ ] Normalize errors into a single shape suitable for UI display and logging.
+
+2. Guest session bootstrap
+   - [ ] Ensure the app creates/resumes a guest session early (app init), and surfaces session state to the UI.
+   - [ ] Ensure all product API requests are scoped to the session (cookies/headers as required by backend).
+
+3. Usable flows
+   - [ ] Character management: list/create/edit/delete backed by real API responses.
+   - [ ] Story/simulation run: start a run, render output, and handle failures/retry.
+   - [ ] Persistence: refresh the page and confirm workspace data is still present.
+
+4. Tests and validation
+   - [ ] Add unit/integration tests for API client error normalization and guest bootstrap.
+   - [ ] Extend Playwright flows to cover “guest → create character → run → refresh → still present”.
+   - [ ] Run full frontend + backend CI checks and `openspec validate refactor-frontend-api-and-ux --strict`.
+

--- a/openspec/changes/standardize-api-surface/design.md
+++ b/openspec/changes/standardize-api-surface/design.md
@@ -1,0 +1,31 @@
+# Design: API Surface Standardization
+
+## Scope
+This change standardizes the **product API surface** (the set of endpoints used by the app frontend and core product integrations). It does not attempt to reorganize internal tooling/observability endpoints unless they overlap with product routes.
+
+## Policy
+
+### Canonical Prefix
+- Canonical prefix for the product API is **`/api`**.
+- The API MUST NOT require path-based versioning for first-party clients.
+
+### Versioned Alias
+- A versioned alias **`/api/v1`** MUST exist for v1 endpoints.
+- `/api/v1/*` MUST behave identically to `/api/*` for the v1 surface.
+
+### Version Semantics
+- `/api/*` is defined as “current stable product API”.
+- Introducing a new stable version (e.g., v2) requires:
+  - explicit proposal
+  - migration guidance
+  - compatibility window for `/api/v1`
+
+## Practical Outcomes
+- Frontend defaults to `/api` to avoid churn when a new version is introduced.
+- External consumers can pin to `/api/v1` when stability is required.
+
+## Backward Compatibility
+- If any legacy paths exist (e.g., `/characters`), they MUST either:
+  - remain as thin redirects/aliases with deprecation signals, or
+  - be removed with an explicit breaking-change proposal.
+

--- a/openspec/changes/standardize-api-surface/proposal.md
+++ b/openspec/changes/standardize-api-surface/proposal.md
@@ -1,0 +1,26 @@
+# Proposal: Standardize API Surface (Paths + Versioning)
+
+## Why
+- The repo currently contains a mix of `/api/*` and `/api/v1/*` references across code and docs, and some modules advertise paths they do not actually implement.
+- Frontend-backend drift has already happened (e.g., mismatched “endpoint maps”, docs, and hooks). Without a single, explicit API surface policy, this will keep recurring.
+- Long-term refactors (guest filesystem workspaces, typed clients, real UI flows) need a stable contract foundation.
+
+## What Changes
+1. **Define a single Product API policy**
+   - Canonical “product API” prefix: `/api/*`.
+   - Explicit versioned alias: `/api/v1/*` MUST remain available for v1-compatible consumers, with identical behavior for v1 endpoints.
+2. **Unify API discovery + docs**
+   - Ensure any “endpoints map” or API reference documents only list routes that exist.
+   - Align example code and environment defaults (frontend + scripts) to the canonical paths.
+3. **Deprecation and compatibility rules**
+   - Document what `/api` means (alias to current stable) and the compatibility expectations for `/api/v1`.
+   - Establish a rule: adding `/api/v2` requires an explicit OpenSpec proposal and migration plan.
+
+## Impact
+- Touches documentation, configuration, and (if needed) route aliasing to ensure both `/api` and `/api/v1` are consistently supported.
+- Reduces breakage risk for downstream consumers and enables a typed “SSOT” client later.
+
+## Out of Scope
+- Large-scale backend module refactors (handled by `refactor-backend-api-platform`).
+- Guest workspace persistence (handled by `add-filesystem-guest-workspaces`).
+

--- a/openspec/changes/standardize-api-surface/specs/api-surface/spec.md
+++ b/openspec/changes/standardize-api-surface/specs/api-surface/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Canonical product API prefix
+The system MUST expose the product API under the canonical prefix `/api/*`.
+
+#### Scenario: Client calls canonical endpoint
+- **WHEN** a client sends a request to a product endpoint under `/api/*` (e.g., `GET /api/characters`)
+- **THEN** the server responds using the canonical contract for that endpoint and includes stable error handling and response shapes.
+
+### Requirement: Versioned v1 alias for the product API
+The system MUST expose a versioned alias for the v1 product API under `/api/v1/*`, with behavior identical to `/api/*` for the v1 surface.
+
+#### Scenario: Client calls versioned alias
+- **GIVEN** a product endpoint exists under `/api/*`
+- **WHEN** a client sends the same request to `/api/v1/*` (e.g., `GET /api/v1/characters`)
+- **THEN** the response status, payload shape, and semantics match the canonical `/api/*` response for v1.
+
+### Requirement: API discovery output is accurate
+Any endpoint map, discovery document, or “available endpoints” output MUST only list routes that are actually served by the running application.
+
+#### Scenario: Endpoint map contains no stale routes
+- **WHEN** a client reads the API’s published endpoint map (if present)
+- **THEN** every listed route can be called and returns a non-404 response when invoked with valid inputs.
+

--- a/openspec/changes/standardize-api-surface/tasks.md
+++ b/openspec/changes/standardize-api-surface/tasks.md
@@ -1,0 +1,18 @@
+## Implementation Tasks
+1. Audit and classify routes
+   - [ ] Inventory all FastAPI route prefixes and list “product API” vs “tooling/observability API”.
+   - [ ] Find and document all `/api/v1` references in code/docs; label each as “must keep”, “must migrate”, or “remove”.
+
+2. Standardize the product API policy
+   - [ ] Ensure product endpoints exist under `/api/*` (canonical).
+   - [ ] Ensure a `/api/v1/*` alias exists for v1 product endpoints (same behavior).
+   - [ ] Ensure any route discovery/endpoints map only lists real routes (no stale `/api/v1/characters` references if not served).
+
+3. Update docs and examples
+   - [ ] Update docs under `docs/api/` and examples under `examples/` to match the policy (frontend uses `/api`, external examples may use `/api/v1`).
+   - [ ] Update security config allowlists/deny rules referencing old paths.
+
+4. Tests and validation
+   - [ ] Add/extend contract tests ensuring `/api/*` and `/api/v1/*` return equivalent responses for the product surface.
+   - [ ] Run full CI validation suite and `openspec validate standardize-api-surface --strict`.
+

--- a/openspec/changes/update-openspec-project-context/proposal.md
+++ b/openspec/changes/update-openspec-project-context/proposal.md
@@ -1,0 +1,18 @@
+# Proposal: Update OpenSpec Project Context
+
+## Why
+- `openspec/project.md` is still a placeholder, so contributors and AI assistants lack a single source of truth for architecture, API conventions, persistence, and CI gates.
+- The repo currently contains multiple backend entrypoints, mixed API path conventions, and both guest + authenticated flows; without documented conventions, future refactors will drift.
+
+## What Changes
+1. Replace the placeholder `openspec/project.md` with project-specific context: purpose, domain model, tech stack, repo structure, and “how we build here”.
+2. Document explicit conventions that make the codebase AI-friendly: stable module boundaries, naming, minimal side effects, and predictable contracts.
+3. Record non-negotiable validation gates and the intended ordering between refactor proposals (API surface → backend platform → filesystem workspaces → frontend).
+
+## Impact
+- Documentation-only change inside `openspec/project.md`.
+- Reduces future proposal churn caused by implicit assumptions.
+
+## Out of Scope
+- Implementing backend/frontend refactors or new features (handled by separate changes).
+

--- a/openspec/changes/update-openspec-project-context/specs/project-context/spec.md
+++ b/openspec/changes/update-openspec-project-context/specs/project-context/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Project context is authoritative
+The repository MUST maintain `openspec/project.md` as the authoritative project context (purpose, tech stack, conventions, and validation gates) and it MUST NOT remain a placeholder template.
+
+#### Scenario: Project context is updated with meaningful content
+- **WHEN** a contributor opens `openspec/project.md`
+- **THEN** it describes the project’s purpose, primary tech stack, architecture conventions, and required CI/validation gates with concrete commands.
+
+### Requirement: Context stays in sync with architecture decisions
+Material changes to architecture patterns, API conventions, or validation gates MUST update `openspec/project.md` in the same change that introduces the new convention.
+
+#### Scenario: New convention updates project context
+- **GIVEN** a change proposal introduces a new convention (e.g., new canonical API prefix, new required CI gate)
+- **WHEN** the change is implemented
+- **THEN** `openspec/project.md` is updated to reflect the convention so future contributors and AI assistants have a single source of truth.
+

--- a/openspec/changes/update-openspec-project-context/tasks.md
+++ b/openspec/changes/update-openspec-project-context/tasks.md
@@ -1,0 +1,15 @@
+## Implementation Tasks
+1. Capture current reality
+   - [ ] Inventory backend entrypoints (root server files vs `src/api/*`) and summarize the “current” launch path used by docs/CI.
+   - [ ] Inventory frontend entrypoints, state management, and API clients/hooks currently in use.
+   - [ ] Inventory persistence locations currently used (e.g., `data/`, `characters/`, `campaigns/`) and which are considered user-owned vs generated.
+
+2. Write authoritative project context
+   - [ ] Fill `openspec/project.md` with: Purpose, Tech Stack, Architecture Patterns, Testing Strategy, Git Workflow, Domain Context, Constraints, and External Dependencies.
+   - [ ] Document API conventions and the decision for canonical prefixes (link to `standardize-api-surface` change).
+   - [ ] Document persistence conventions (guest-first, filesystem-backed) and where data MUST live.
+   - [ ] Add an “AI-friendly” section: stable boundaries, “where to add code”, and preferred patterns for new endpoints/components.
+
+3. Validation
+   - [ ] Run `openspec validate update-openspec-project-context --strict` and resolve any issues.
+


### PR DESCRIPTION
Adds 5 OpenSpec change proposals to guide the long-term refactor roadmap:\n- update-openspec-project-context\n- standardize-api-surface\n- refactor-backend-api-platform\n- add-filesystem-guest-workspaces\n- refactor-frontend-api-and-ux\n\nAll changes validate with openspec validate <change> --strict.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds five OpenSpec changes defining the product API policy, a canonical backend app platform, filesystem-backed guest workspaces, a unified frontend API/UX flow, and an authoritative project context with specs and tasks.
> 
> - **OpenSpec changes (5)**:
>   - **`standardize-api-surface`**: defines canonical `/api/*` with `/api/v1/*` alias; requires accurate discovery; adds contract tests/tasks.
>   - **`refactor-backend-api-platform`**: introduces FastAPI `create_app()` factory, domain routers, standardized error envelope, and OpenAPI as contract; includes migration tasks.
>   - **`add-filesystem-guest-workspaces`**: proposes guest-first filesystem workspaces with atomic writes, isolation, manifest/schemaVersion, and export/import; aligns character service to session/workspace.
>   - **`refactor-frontend-api-and-ux`**: establishes single typed API client, guest session bootstrap, real character/run flows, and consistent error handling; adds test/UX tasks.
>   - **`update-openspec-project-context`**: makes `openspec/project.md` authoritative for architecture/conventions and mandates updates with future changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1827a5e03a95f995b036d73e20443f4553516c0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->