### PR TITLE
Finalize dashboard accessibility parity

### DIFF
--- a/docs/testing/uat/UAT_DAY5_INTEGRATION_REGRESSION_TESTING.md
+++ b/docs/testing/uat/UAT_DAY5_INTEGRATION_REGRESSION_TESTING.md
@@ -223,6 +223,20 @@
 结论: Bug修复不仅解决了功能问题，还带来了性能改善
 ```
 
+#### Dashboard Accessibility Parity 回归验证 (2025-12-31)
+```
+验证范围: Dashboard 键盘可达性 + API 数据回填 + aria-live 通知
+
+执行步骤:
+- Vitest: frontend/src/features/dashboard/__tests__/dashboard-accessibility.test.tsx
+- Playwright: tests/e2e/accessibility.spec.ts
+
+验证结果:
+✅ 关键控件支持键盘操作 (Enter/Space)
+✅ World Map + Character Networks 使用 /api/characters 数据源并显示 API feed
+✅ pipeline live indicator 带 aria-live="polite" 且状态变更可观察
+```
+
 ## 第5天测试总结
 
 ### 集成测试结果

--- a/frontend/src/features/dashboard/CharacterNetworks.tsx
+++ b/frontend/src/features/dashboard/CharacterNetworks.tsx
@@ -1,24 +1,19 @@
 import React, { useMemo, useRef, useState, useEffect, useCallback } from 'react';
-import {
-  Box,
-  Typography,
-  Chip,
-  Stack,
-  List,
-  Avatar,
-  LinearProgress,
-  useTheme,
-  useMediaQuery,
-  Fade,
-} from '@mui/material';
-import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import List from '@mui/material/List';
+import Avatar from '@mui/material/Avatar';
+import LinearProgress from '@mui/material/LinearProgress';
+import Fade from '@mui/material/Fade';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { styled, useTheme } from '@mui/material/styles';
 import { motion } from 'framer-motion';
-import {
-  Person as PersonIcon,
-  Groups as GroupIcon,
-  Link as LinkIcon,
-  Diversity3 as NetworkIcon,
-} from '@mui/icons-material';
+import PersonIcon from '@mui/icons-material/Person';
+import GroupIcon from '@mui/icons-material/Groups';
+import LinkIcon from '@mui/icons-material/Link';
+import NetworkIcon from '@mui/icons-material/Diversity3';
 import GridTile from '@/components/layout/GridTile';
 import { useDashboardCharactersDataset } from '@/hooks/useDashboardCharactersDataset';
 

--- a/frontend/src/features/dashboard/NarrativeTimeline.tsx
+++ b/frontend/src/features/dashboard/NarrativeTimeline.tsx
@@ -1,25 +1,20 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import {
-  Box,
-  Typography,
-  Chip,
-  Stack,
-  LinearProgress,
-  Avatar,
-  useTheme,
-  useMediaQuery,
-  Fade,
-} from '@mui/material';
-import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import LinearProgress from '@mui/material/LinearProgress';
+import Avatar from '@mui/material/Avatar';
+import Fade from '@mui/material/Fade';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { styled, useTheme } from '@mui/material/styles';
 import { motion } from 'framer-motion';
-import {
-  CheckCircle as CompletedIcon,
-  RadioButtonUnchecked as PendingIcon,
-  PlayCircle as ActiveIcon,
-  MenuBook as ChapterIcon,
-  AutoStories as StoryIcon,
-  TrendingFlat as ConnectionIcon,
-} from '@mui/icons-material';
+import CompletedIcon from '@mui/icons-material/CheckCircle';
+import PendingIcon from '@mui/icons-material/RadioButtonUnchecked';
+import ActiveIcon from '@mui/icons-material/PlayCircle';
+import ChapterIcon from '@mui/icons-material/MenuBook';
+import StoryIcon from '@mui/icons-material/AutoStories';
+import ConnectionIcon from '@mui/icons-material/TrendingFlat';
 import GridTile from '@/components/layout/GridTile';
 
 const TimelineContainer = styled(Box)(({ theme }) => ({

--- a/frontend/src/features/dashboard/QuickActions.tsx
+++ b/frontend/src/features/dashboard/QuickActions.tsx
@@ -1,27 +1,23 @@
 import React, { useEffect, useRef } from 'react';
-import {
-  Box,
-  IconButton,
-  Tooltip,
-  Stack,
-  Typography,
-  useMediaQuery,
-  Fade,
-  Chip,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Fade from '@mui/material/Fade';
+import Chip from '@mui/material/Chip';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { styled } from '@mui/material/styles';
 import { motion } from 'framer-motion';
-import {
-  PlayArrow as PlayIcon,
-  Pause as PauseIcon,
-  Stop as StopIcon,
-  Refresh as RefreshIcon,
-  Save as SaveIcon,
-  Settings as SettingsIcon,
-  Fullscreen as FullscreenIcon,
-  Download as DownloadIcon,
-  PersonAdd as PersonAddIcon,
-} from '@mui/icons-material';
+import PlayIcon from '@mui/icons-material/PlayArrow';
+import PauseIcon from '@mui/icons-material/Pause';
+import StopIcon from '@mui/icons-material/Stop';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import SaveIcon from '@mui/icons-material/Save';
+import SettingsIcon from '@mui/icons-material/Settings';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import DownloadIcon from '@mui/icons-material/Download';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import GridTile from '@/components/layout/GridTile';
 import { telemetry } from '../../utils/telemetry';
 

--- a/frontend/src/features/dashboard/RealTimeActivity.tsx
+++ b/frontend/src/features/dashboard/RealTimeActivity.tsx
@@ -1,29 +1,24 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-  Box,
-  List,
-  ListItem,
-  Typography,
-  Chip,
-  Avatar,
-  Stack,
-  Badge,
-  useTheme,
-  useMediaQuery,
-  Fade,
-  Button,
-  Alert,
-} from '@mui/material';
-import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Avatar from '@mui/material/Avatar';
+import Stack from '@mui/material/Stack';
+import Badge from '@mui/material/Badge';
+import Fade from '@mui/material/Fade';
+import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { styled, useTheme } from '@mui/material/styles';
 import { motion, AnimatePresence } from 'framer-motion';
-import {
-  Person as PersonIcon,
-  AutoStories as StoryIcon,
-  Psychology as BrainIcon,
-  Speed as ActivityIcon,
-  Notifications as NotificationIcon,
-  Error as AlertCircleIcon,
-} from '@mui/icons-material';
+import PersonIcon from '@mui/icons-material/Person';
+import StoryIcon from '@mui/icons-material/AutoStories';
+import BrainIcon from '@mui/icons-material/Psychology';
+import ActivityIcon from '@mui/icons-material/Speed';
+import NotificationIcon from '@mui/icons-material/Notifications';
+import AlertCircleIcon from '@mui/icons-material/Error';
 import GridTile from '@/components/layout/GridTile';
 import { useRealtimeEvents } from '../../hooks/useRealtimeEvents';
 

--- a/frontend/src/features/dashboard/TurnPipelineStatus.tsx
+++ b/frontend/src/features/dashboard/TurnPipelineStatus.tsx
@@ -263,6 +263,8 @@ const TurnPipelineStatus: React.FC<TurnPipelineStatusProps> = ({
               color="success"
               size="small"
               data-testid="pipeline-live-indicator"
+              aria-live="polite"
+              aria-atomic="true"
               sx={{
                 fontWeight: 700,
                 letterSpacing: '0.04em',
@@ -276,6 +278,8 @@ const TurnPipelineStatus: React.FC<TurnPipelineStatusProps> = ({
                label="ONLINE"
                size="small"
                data-testid="pipeline-live-indicator"
+               aria-live="polite"
+               aria-atomic="true"
                sx={{
                 backgroundColor: 'rgba(255, 255, 255, 0.05)',
                 color: (theme) => theme.palette.text.secondary,
@@ -292,6 +296,8 @@ const TurnPipelineStatus: React.FC<TurnPipelineStatusProps> = ({
               color="error"
               size="small"
               data-testid="pipeline-live-indicator"
+              aria-live="polite"
+              aria-atomic="true"
               sx={{
                 fontWeight: 700,
                 letterSpacing: '0.04em',

--- a/frontend/src/features/dashboard/WorldStateMap.tsx
+++ b/frontend/src/features/dashboard/WorldStateMap.tsx
@@ -1,23 +1,18 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import {
-  Box,
-  Chip,
-  Stack,
-  Typography,
-  Avatar,
-  List,
-  ListItem,
-  ListItemAvatar,
-  ListItemText,
-  useTheme,
-} from '@mui/material';
-import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Avatar from '@mui/material/Avatar';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemAvatar from '@mui/material/ListItemAvatar';
+import ListItemText from '@mui/material/ListItemText';
+import { styled, useTheme } from '@mui/material/styles';
 import { motion, AnimatePresence } from 'framer-motion';
-import {
-  LocationOn as LocationIcon,
-  Person as PersonIcon,
-  Timeline as ActivityIcon,
-} from '@mui/icons-material';
+import LocationIcon from '@mui/icons-material/LocationOn';
+import PersonIcon from '@mui/icons-material/Person';
+import ActivityIcon from '@mui/icons-material/Timeline';
 import GridTile from '@/components/layout/GridTile';
 import { useDashboardCharactersDataset, type DashboardCharacter } from '@/hooks/useDashboardCharactersDataset';
 

--- a/frontend/src/features/dashboard/__tests__/dashboard-accessibility.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/dashboard-accessibility.test.tsx
@@ -1,80 +1,167 @@
-/**
- * Dashboard Accessibility Tests
- *
- * NOTE: These tests are temporarily skipped due to MUI barrel export performance issues
- * in Vitest. The @mui/material and @mui/icons-material barrel exports cause test
- * initialization to hang indefinitely during module resolution.
- *
- * Root cause: Components in this directory use barrel imports like:
- *   import { Box, Typography } from '@mui/material';
- *   import { PlayIcon, PauseIcon } from '@mui/icons-material';
- *
- * These barrel exports re-export thousands of components/icons, causing Vitest
- * to resolve all of them during test setup.
- *
- * Solutions (in order of preference):
- * 1. Refactor components to use direct imports:
- *    import Box from '@mui/material/Box';
- *    import PlayIcon from '@mui/icons-material/PlayArrow';
- *
- * 2. Configure Vitest with better tree-shaking (requires Vitest 2.x+ features)
- *
- * 3. Use jest instead of vitest for MUI-heavy tests
- *
- * The test logic and assertions below are correct - only the MUI import
- * performance prevents them from running.
- */
-import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import QuickActions from '../QuickActions';
+import WorldStateMap from '../WorldStateMap';
+import CharacterNetworks from '../CharacterNetworks';
+import NarrativeTimeline from '../NarrativeTimeline';
+import RealTimeActivity from '../RealTimeActivity';
 
-// Skip all tests in this file due to MUI barrel import performance issues
-describe.skip('Dashboard accessibility + data parity', () => {
-  // Tests are skipped - see file header comment for explanation
+const mockDashboardDataset = vi.fn();
+const mockRealtimeEvents = vi.fn();
+
+vi.mock('@/hooks/useDashboardCharactersDataset', () => ({
+  useDashboardCharactersDataset: () => mockDashboardDataset(),
+}));
+
+vi.mock('@/hooks/useRealtimeEvents', () => ({
+  useRealtimeEvents: () => mockRealtimeEvents(),
+}));
+
+const sampleCharacters = [
+  { id: 'aria', name: 'Aria Shadowbane', status: 'active', role: 'protagonist', trust: 82 },
+  { id: 'lyra', name: 'Captain Lyra', status: 'inactive', role: 'npc', trust: 64 },
+  { id: 'kael', name: 'Kael Voss', status: 'hostile', role: 'antagonist', trust: 40 },
+];
+
+describe('Dashboard accessibility + data parity', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockDashboardDataset.mockReturnValue({
+      characters: sampleCharacters,
+      loading: false,
+      error: null,
+      source: 'api',
+    });
+    mockRealtimeEvents.mockReturnValue({
+      events: [],
+      loading: false,
+      error: null,
+      connectionState: 'connected',
+    });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 
   it('renders QuickActions without leaking invalid DOM props', () => {
-    expect(true).toBe(true);
+    render(<QuickActions />);
+
+    const hasInvalidPropWarning = errorSpy.mock.calls.some(([message]) =>
+      typeof message === 'string' &&
+      (message.includes('React does not recognize the') || message.includes('Invalid DOM property'))
+    );
+
+    expect(hasInvalidPropWarning).toBe(false);
   });
 
   it('shows connection chip and live text as ONLINE when idle but connected', () => {
-    expect(true).toBe(true);
+    render(<QuickActions />);
+
+    expect(screen.getByTestId('connection-status')).toHaveAttribute('data-status', 'online');
+    expect(screen.getByTestId('live-indicator')).toHaveTextContent('ONLINE');
   });
 
   it('fetches characters for spatial + network tiles and surfaces API data', () => {
-    expect(true).toBe(true);
+    render(
+      <>
+        <WorldStateMap />
+        <CharacterNetworks />
+      </>
+    );
+
+    const mapTile = screen.getByTestId('world-state-map');
+    const networkTile = screen.getByTestId('character-networks');
+
+    expect(within(mapTile).getByText('3 Characters')).toBeInTheDocument();
+    expect(within(networkTile).getByText('3 Characters')).toBeInTheDocument();
+    expect(within(mapTile).getByText('API feed')).toBeInTheDocument();
+    expect(within(networkTile).getByText('API feed')).toBeInTheDocument();
   });
 
   it('falls back to demo data when the API request fails without showing tile errors', () => {
-    expect(true).toBe(true);
-  });
+    mockDashboardDataset.mockReturnValue({
+      characters: sampleCharacters,
+      loading: false,
+      error: 'offline',
+      source: 'fallback',
+    });
 
-  it('displays character and active counts sourced from the dataset', () => {
-    expect(true).toBe(true);
-  });
+    render(
+      <>
+        <WorldStateMap />
+        <CharacterNetworks />
+      </>
+    );
 
-  it('surfaces API feed badges for map and network tiles when the API succeeds', () => {
-    expect(true).toBe(true);
-  });
+    const mapTile = screen.getByTestId('world-state-map');
+    const networkTile = screen.getByTestId('character-networks');
 
-  it('renders characters from API data correctly', () => {
-    expect(true).toBe(true);
+    expect(within(mapTile).getByText('Demo data')).toBeInTheDocument();
+    expect(within(networkTile).getByText('Demo data')).toBeInTheDocument();
   });
 
   it('supports keyboard activation for world map markers', () => {
-    expect(true).toBe(true);
+    render(<WorldStateMap />);
+
+    const markers = screen.getAllByRole('button');
+    expect(markers.length).toBeGreaterThan(1);
+
+    fireEvent.keyDown(markers[1], { key: 'Enter' });
+    expect(markers[1]).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('exposes character network cards as focusable buttons', () => {
-    expect(true).toBe(true);
+    render(<CharacterNetworks />);
+
+    const cards = screen.getAllByTestId('character-node');
+    expect(cards.length).toBeGreaterThan(0);
+    expect(cards[0]).toHaveAttribute('role', 'button');
+    expect(cards[0]).toHaveAttribute('tabindex', '0');
+
+    fireEvent.keyDown(cards[0], { key: 'Enter' });
+    expect(cards[0]).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('marks narrative timeline nodes with aria-current metadata', () => {
-    expect(true).toBe(true);
+    render(<NarrativeTimeline />);
+
+    const currentNode = screen.getAllByTestId('timeline-node').find((node) =>
+      node.getAttribute('data-status') === 'current'
+    );
+
+    expect(currentNode).toBeTruthy();
+    expect(currentNode).toHaveAttribute('aria-current', 'step');
   });
 
-  it('renders QuickActions and timeline/pipeline tiles without console warnings', () => {
-    expect(true).toBe(true);
+  it('renders QuickActions and narrative timeline without console warnings', () => {
+    render(
+      <>
+        <QuickActions />
+        <NarrativeTimeline />
+      </>
+    );
+
+    const hasWarning = warnSpy.mock.calls.some(([message]) =>
+      typeof message === 'string' && message.includes('Warning')
+    );
+
+    expect(hasWarning).toBe(false);
   });
 
   it('renders RealTimeActivity without DOM nesting warnings', () => {
-    expect(true).toBe(true);
+    render(<RealTimeActivity />);
+
+    const hasNestingWarning = errorSpy.mock.calls.some(([message]) =>
+      typeof message === 'string' && message.includes('validateDOMNesting')
+    );
+
+    expect(hasNestingWarning).toBe(false);
   });
 });

--- a/openspec/changes/dashboard-accessibility-parity/proposal.md
+++ b/openspec/changes/dashboard-accessibility-parity/proposal.md
@@ -5,6 +5,15 @@
 - Quick Actions leak the custom `active` prop down to native `<button>` elements (`frontend/src/components/dashboard/QuickActions.tsx:27-55`), triggering persistent React console warnings (`list_console_messages` msgid 141) and offering inconsistent focus outlines.
 - Spatial/Network tiles still ship with hard-coded demo data (`WorldStateMapV2` locations array, `CharacterNetworks` `useState` stub) and never reconcile against `GET /characters` or related endpoints, so the UI cannot meet audit step §9 (API validation). The dashboard has effectively never rendered real payloads.
 
+## Evidence
+- MCP audit snapshot: `mcp__chrome-devtools__take_snapshot` ids 8_85-8_219
+- Console warnings: `list_console_messages` msgid 141 (invalid DOM props)
+
+## Acceptance Criteria
+- Keyboard users can activate map markers, character cards, and timeline entries with Enter/Space; focus/ARIA states update without console warnings.
+- Map + network tiles render API-sourced character data from `/api/characters` (with fallback data if offline), and show the correct “API feed” or “Demo data” badge.
+- Quick Actions renders without leaking custom props and exposes consistent `:focus-visible` styling and `aria-pressed` state changes.
+
 ## What Changes
 1. **Keyboard semantics** – Implement roving tab index/focus management for map markers, character cards, and timeline nodes. Support Space/Enter activation, `aria-selected`/`aria-expanded` states, and deterministic selectors so Playwright/MCP can assert them.
 2. **QuickAction hygiene** – Prevent custom props from leaking to DOM, add explicit `:focus-visible` styles, and ensure telemetry buttons announce state changes via `aria-pressed` or text updates without console noise.

--- a/openspec/changes/dashboard-accessibility-parity/tasks.md
+++ b/openspec/changes/dashboard-accessibility-parity/tasks.md
@@ -1,17 +1,17 @@
 ## Implementation Tasks
 1. Evidence + planning
-   - [ ] Link MCP audit screenshots/logs to this change and outline acceptance criteria (keyboard activation, API parity, console cleanliness).
-   - [ ] Align with backend contract for `/characters` payload shape; capture sample fixture for tests.
+   - [x] Link MCP audit screenshots/logs to this change and outline acceptance criteria (keyboard activation, API parity, console cleanliness).
+   - [x] Align with backend contract for `/characters` payload shape; capture sample fixture for tests.
 2. Spec & proposal wiring
-   - [ ] Update `openspec/specs/dashboard-interactions` with new requirements/scenarios (keyboard semantics, API-backed tiles, quick-action hygiene).
-   - [ ] Run `openspec validate dashboard-accessibility-parity --strict` once docs/specs are ready.
+   - [x] Update `openspec/specs/dashboard-interactions` with new requirements/scenarios (keyboard semantics, API-backed tiles, quick-action hygiene).
+   - [x] Run `openspec validate dashboard-accessibility-parity --strict` once docs/specs are ready.
 3. Tests-first (TDD)
-   - [ ] Add/extend Vitest suites for `WorldStateMapV2`, `CharacterNetworks`, `NarrativeTimeline`, and `QuickActions` to assert keyboard behaviour, aria attributes, and console-silence (use `vi.spyOn(console, 'error')`).
-   - [ ] Add integration test to confirm map/network consume mocked `/characters` data and reflect counts/names.
+   - [x] Add/extend Vitest suites for `WorldStateMapV2`, `CharacterNetworks`, `NarrativeTimeline`, and `QuickActions` to assert keyboard behaviour, aria attributes, and console-silence (use `vi.spyOn(console, 'error')`).
+   - [x] Add integration test to confirm map/network consume mocked `/characters` data and reflect counts/names.
 4. Implementation
-   - [ ] Implement roving-tabindex + enter/space handlers and aria metadata for the tiles per spec.
-   - [ ] Refactor QuickActions to filter props, add focus-visible styles, and broadcast state transitions via accessible text.
-   - [ ] Introduce data hook/service (e.g., `useCharactersDataset`) reused by map + networks; ensure graceful fallback when API offline.
+   - [x] Implement roving-tabindex + enter/space handlers and aria metadata for the tiles per spec.
+   - [x] Refactor QuickActions to filter props, add focus-visible styles, and broadcast state transitions via accessible text.
+   - [x] Introduce data hook/service (e.g., `useCharactersDataset`) reused by map + networks; ensure graceful fallback when API offline.
 5. Validation & docs
-   - [ ] Re-run `npm run lint`, `npm run type-check`, `npm test -- --run` and relevant Playwright accessibility specs.
-   - [ ] Update audit/UAT docs with new evidence; attach new MCP screenshots if layout changed.
+   - [x] Re-run `npm run lint`, `npm run type-check`, `npm test -- --run` and relevant Playwright accessibility specs.
+   - [x] Update audit/UAT docs with new evidence; attach new MCP screenshots if layout changed.


### PR DESCRIPTION
## Summary\n- Enable dashboard accessibility coverage by switching targeted components to direct MUI imports and adding parity tests.\n- Align accessibility Playwright flow with mocked API bootstrap and pipeline live indicator announcements.\n- Document dashboard accessibility parity verification in UAT regression notes.\n\n## Testing\n- \.\.venv\\Scripts\\python -m pytest tests -v\n- \.\.venv\\Scripts\\mypy src (fails: 3300 existing type errors)\n- npm run test\n- npm run type-check\n- npm run lint:all (warnings only)\n- npm run test:e2e:smoke\n- npx playwright test tests/e2e/accessibility.spec.ts