### PR TITLE
fix(ci): remove reference to deleted test_enhanced_bridge.py file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
 
       - name: Run smoke tests with JUnit XML
         run: |
-          pytest -q tests/test_enhanced_bridge.py tests/test_character_system_comprehensive.py --junitxml=reports/smoke-tests.xml
+          pytest -q tests/test_character_system_comprehensive.py tests/smoke/ --junitxml=reports/smoke-tests.xml
 
       - name: Upload smoke test results
         if: always()


### PR DESCRIPTION
The file tests/test_enhanced_bridge.py was removed during the repo sanitation, but the CI smoke-tests job still referenced it, causing CI failures.

Updated smoke tests to run:
- tests/test_character_system_comprehensive.py (existing file)
- tests/smoke/ directory (existing smoke tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts CI smoke test selection to eliminate a reference to a removed test and include existing smoke coverage.
> 
> - Updates `Run smoke tests with JUnit XML` step in `.github/workflows/ci.yml` to run `tests/test_character_system_comprehensive.py` and `tests/smoke/` instead of the deleted `tests/test_enhanced_bridge.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9556d80b6e46f5467233cb8cae5e88e7e0597f9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->