### PR TITLE
fix(ci): Add pytest timeout to prevent false failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,10 +210,11 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+timeout = 300  # Global timeout to prevent external process termination
 addopts = [
     "-v",
     "--tb=short",
-    "-p", "asyncio", 
+    "-p", "asyncio",
     "--asyncio-mode=auto"
 ]
 


### PR DESCRIPTION
## Summary
- Add `timeout = 300` to pytest.ini_options in pyproject.toml
- Prevents false "FAILED" reports when CI runs via Task tool with timeout
- The pytest-timeout plugin was already installed but no global timeout was configured

## Problem
The CI check script reported "FAILED" with "Terminated" even when all 4974 tests passed. This was caused by external process termination when running via Task tool.

## Solution
Configure pytest-timeout plugin with a 300-second global timeout, so pytest handles timeouts internally rather than being externally terminated.

## Test Plan
- [x] Verified `timeout: 300.0s` appears in pytest output
- [x] All unit tests pass (4974 passed, 84 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)