### PR TITLE
[codex] honcho and ai provider resilience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,18 @@ jobs:
           --cov-fail-under=80
           -q
 
+      - name: Run Honcho and AI provider coverage gate
+        run: >
+          uv run pytest
+          tests/shared/infrastructure/honcho
+          tests/contexts/ai
+          --cov=src/shared/infrastructure/honcho
+          --cov=src.shared.infrastructure.health.checks.honcho_health_check
+          --cov=src/contexts/ai/infrastructure/providers
+          --cov-report=term-missing
+          --cov-fail-under=80
+          -q
+
   frontend:
     name: Frontend Validation
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test:
 	uv run pytest -q
 	uv run pytest tests/unit/infrastructure tests/apps/api/test_health.py --cov=src/shared/infrastructure/auth --cov=src/shared/infrastructure/config --cov=src/shared/infrastructure/health --cov=src/shared/infrastructure/persistence --cov-report=term-missing --cov-fail-under=80 -q
 	uv run pytest tests/shared/infrastructure/circuit_breaker tests/shared/infrastructure/middleware tests/apps/api/middleware --cov=src/shared/infrastructure/circuit_breaker --cov=src/shared/infrastructure/middleware --cov=src/apps/api/middleware --cov-report=term-missing --cov-fail-under=80 -q
+	uv run pytest tests/shared/infrastructure/honcho tests/contexts/ai --cov=src/shared/infrastructure/honcho --cov=src.shared.infrastructure.health.checks.honcho_health_check --cov=src/contexts/ai/infrastructure/providers --cov-report=term-missing --cov-fail-under=80 -q
 
 lint:
 	uv run ruff check src/ tests/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ uv run pytest \
   --cov-report=term-missing \
   --cov-fail-under=80 \
   -q
+uv run pytest \
+  tests/shared/infrastructure/honcho \
+  tests/contexts/ai \
+  --cov=src/shared/infrastructure/honcho \
+  --cov=src.shared.infrastructure.health.checks.honcho_health_check \
+  --cov=src/contexts/ai/infrastructure/providers \
+  --cov-report=term-missing \
+  --cov-fail-under=80 \
+  -q
 uv run ruff check src tests
 uv run mypy \
   src \
@@ -57,6 +66,10 @@ If you want the optional Honcho integration installed locally, use:
 ```bash
 uv sync --extra dev --extra test --extra honcho --frozen
 ```
+
+PR CI does not require live Honcho credentials. The default Honcho and AI provider
+tests use mocks and deterministic providers; live Honcho smoke remains opt-in with
+`ENABLE_HONCHO_TESTS=1`.
 
 ### Frontend
 
@@ -107,6 +120,7 @@ See [docs/reports/uat/INDEX.md](docs/reports/uat/INDEX.md) and [docs/reports/uat
 - `uv run pytest -q` is the default backend behavior gate.
 - Platform infrastructure coverage is gated at 80% across auth, config, health, and persistence modules.
 - Circuit breaker and middleware coverage is gated at 80% across shared circuit breaker, shared middleware, and API middleware modules.
+- Honcho and AI provider infrastructure coverage is gated at 80% with mock-based tests; live DashScope and Honcho credentials are not required for PR CI.
 - External-service-heavy tests are opt-in through explicit environment flags in `tests/conftest.py`.
 - Frontend smoke and full-audit coverage are exercised with Playwright against the canonical backend and frontend stack.
 - Frontend dependency drift is gated with `npm --prefix frontend run audit:dependencies` (Knip-based static audit).
@@ -117,6 +131,7 @@ See [docs/reports/uat/INDEX.md](docs/reports/uat/INDEX.md) and [docs/reports/uat
 - CI runs backend quality on the canonical backend surface, backend tests, 80% platform and circuit/middleware coverage floors, frontend platform coverage, frontend validation, frontend full-audit, public API audit, OpenAPI snapshot check, import-linter, and CodeQL.
 - `DashScope Longform Gate` is a required PR check for same-repo pull requests into protected branches.
 - The canonical checked-in UAT evidence is refreshed manually; normal PR gate runs only upload artifacts.
+- DashScope live provider contracts and long-form UAT remain manual or opt-in through `ENABLE_DASHSCOPE_TESTS=1` plus `DASHSCOPE_API_KEY`.
 - The long-form gate is only green when the real run reaches `publish=success` with `warning=0` and `blocker=0`.
 - CodeQL scans the canonical source surface only; generated caches and build outputs are excluded, and default-branch merges must keep the scan clean or use documented suppressions for confirmed false positives. See [docs/security/codeql-alerts.md](docs/security/codeql-alerts.md).
 

--- a/src/shared/infrastructure/health/checks/honcho_health_check.py
+++ b/src/shared/infrastructure/health/checks/honcho_health_check.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 from src.shared.infrastructure.health.health_checker import HealthStatus
 from src.shared.infrastructure.honcho.client import HonchoClient
 
@@ -23,7 +25,18 @@ class HonchoHealthCheck:
         try:
             health_check = getattr(self.client, "health_check", None)
             if callable(health_check):
-                is_healthy = await health_check()
+                health_result = health_check()
+                if inspect.isawaitable(health_result):
+                    health_result = await health_result
+                if isinstance(health_result, HealthStatus):
+                    return health_result
+                if health_result in ("healthy", "degraded", "unhealthy"):
+                    return HealthStatus(
+                        status=str(health_result),
+                        message=f"Honcho service reported {health_result}",
+                    )
+
+                is_healthy = bool(health_result)
                 return HealthStatus(
                     status="healthy" if is_healthy else "unhealthy",
                     message=(

--- a/src/shared/infrastructure/honcho/client.py
+++ b/src/shared/infrastructure/honcho/client.py
@@ -81,7 +81,7 @@ class HonchoClient:
         elif isinstance(error, TimeoutError):
             return "TIMEOUT_ERROR"
         elif isinstance(error, HonchoClientError):
-            return "HONCHO_CLIENT_ERROR"
+            return error.error_code
         else:
             return "UNKNOWN_ERROR"
 
@@ -105,10 +105,21 @@ class HonchoClient:
                             details=HonchoErrorDetails(
                                 operation="initialize",
                                 entity_id="honcho_client",
-                                error_code="HONCHO_CLIENT_ERROR",
+                                error_code="HONCHO_PACKAGE_MISSING",
                                 original_exception=ImportError(
                                     "honcho package is not installed"
                                 ),
+                            ),
+                        )
+
+                    if self._settings.is_cloud and not self._settings.api_key:
+                        raise HonchoClientError(
+                            "HONCHO_API_KEY is required for Honcho cloud deployment",
+                            details=HonchoErrorDetails(
+                                operation="initialize",
+                                entity_id="honcho_client",
+                                error_code="CONFIGURATION_ERROR",
+                                context={"deployment": self._settings.deployment},
                             ),
                         )
 
@@ -122,7 +133,19 @@ class HonchoClient:
                             client_kwargs["api_key"] = self._settings.api_key
 
                         self._client = _Honcho(**client_kwargs)
+                    except HonchoClientError:
+                        raise
                     except (ConnectionError, TimeoutError) as e:
+                        raise HonchoClientError(
+                            f"Failed to initialize Honcho client: {e}",
+                            details=HonchoErrorDetails(
+                                operation="initialize",
+                                entity_id="honcho_client",
+                                error_code=self._classify_error(e),
+                                original_exception=e,
+                            ),
+                        ) from e
+                    except Exception as e:
                         raise HonchoClientError(
                             f"Failed to initialize Honcho client: {e}",
                             details=HonchoErrorDetails(
@@ -284,6 +307,9 @@ class HonchoClient:
                 return True
             except Exception:
                 continue
+
+        if any(callable(getattr(client, probe_name, None)) for probe_name in ("health", "ping", "status")):
+            return False
 
         return True
 

--- a/src/shared/infrastructure/honcho/message_handler.py
+++ b/src/shared/infrastructure/honcho/message_handler.py
@@ -67,7 +67,9 @@ class HonchoMessageHandler:
                 metadata=metadata or {},
             )
             return message
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to add message to session {session_id}: {e}",
                 details=HonchoErrorDetails(
@@ -128,7 +130,9 @@ class HonchoMessageHandler:
                     top_k=top_k,
                 )
             return results if isinstance(results, list) else []
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to search memories for peer {peer_id}: {e}",
                 details=HonchoErrorDetails(
@@ -182,7 +186,9 @@ class HonchoMessageHandler:
                     peer_id=peer_id,
                 )
             return cast(str, representation.content if representation else "")
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to get representation for peer {peer_id}: {e}",
                 details=HonchoErrorDetails(
@@ -235,7 +241,9 @@ class HonchoMessageHandler:
                     query=query,
                 )
             return cast(str, response.content if response else "")
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to chat with peer {peer_id}: {e}",
                 details=HonchoErrorDetails(

--- a/src/shared/infrastructure/honcho/session_manager.py
+++ b/src/shared/infrastructure/honcho/session_manager.py
@@ -57,7 +57,9 @@ class HonchoSessionManager:
                 metadata=metadata or {},
             )
             return session
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to create session for peer {peer_id}: {e}",
                 details=HonchoErrorDetails(
@@ -103,7 +105,9 @@ class HonchoSessionManager:
             )
             context_data = context.to_openai() if hasattr(context, "to_openai") else []
             return cast(list[dict[str, Any]], context_data)
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to get session context for {session_id}: {e}",
                 details=HonchoErrorDetails(

--- a/src/shared/infrastructure/honcho/workspace_manager.py
+++ b/src/shared/infrastructure/honcho/workspace_manager.py
@@ -53,6 +53,16 @@ class HonchoWorkspaceManager:
         except (ConnectionError, TimeoutError, HonchoClientError):
             # Workspace doesn't exist or connection issue, continue to create
             pass
+        except Exception as e:
+            raise HonchoClientError(
+                f"Failed to get workspace {workspace_id}: {e}",
+                details=HonchoErrorDetails(
+                    operation="get_workspace",
+                    entity_id=workspace_id,
+                    error_code=self._classify_error(e),
+                    original_exception=e,
+                ),
+            ) from e
 
         # Create new workspace
         try:
@@ -61,7 +71,9 @@ class HonchoWorkspaceManager:
                 name=name or workspace_id,
             )
             return workspace
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to create workspace {workspace_id}: {e}",
                 details=HonchoErrorDetails(
@@ -100,6 +112,17 @@ class HonchoWorkspaceManager:
         except (ConnectionError, TimeoutError, HonchoClientError):
             # Peer doesn't exist or connection issue, continue to create
             pass
+        except Exception as e:
+            raise HonchoClientError(
+                f"Failed to get peer {peer_id}: {e}",
+                details=HonchoErrorDetails(
+                    operation="get_peer",
+                    entity_id=peer_id,
+                    error_code=self._classify_error(e),
+                    original_exception=e,
+                    context={"workspace_id": workspace_id},
+                ),
+            ) from e
 
         try:
             peer = await client.peers.create(
@@ -108,7 +131,9 @@ class HonchoWorkspaceManager:
                 name=name or peer_id,
             )
             return peer
-        except (ConnectionError, TimeoutError) as e:
+        except HonchoClientError:
+            raise
+        except Exception as e:
             raise HonchoClientError(
                 f"Failed to create peer {peer_id}: {e}",
                 details=HonchoErrorDetails(

--- a/tests/contexts/ai/infrastructure/test_text_generation_providers.py
+++ b/tests/contexts/ai/infrastructure/test_text_generation_providers.py
@@ -1,0 +1,494 @@
+"""Mocked text-generation provider resilience tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from src.contexts.ai.application.ports.text_generation_port import (
+    TextGenerationProviderError,
+    TextGenerationResult,
+    TextGenerationTask,
+)
+from src.contexts.ai.infrastructure.providers.dashscope_text_generation_provider import (
+    DashScopeTextGenerationProvider,
+)
+from src.contexts.ai.infrastructure.providers.deterministic_text_generation_provider import (
+    DeterministicTextGenerationProvider,
+)
+from src.contexts.ai.infrastructure.providers.openai_compatible_text_generation_provider import (
+    OpenAICompatibleTextGenerationProvider,
+)
+from src.contexts.ai.infrastructure.providers.provider_factory import (
+    create_text_generation_provider,
+)
+from src.contexts.ai.infrastructure.providers.unconfigured_text_generation_provider import (
+    UnconfiguredTextGenerationProvider,
+)
+from src.shared.infrastructure.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerOpenError,
+)
+from src.shared.infrastructure.config.settings import NovelEngineSettings
+
+
+def _task(
+    step: str = "bible",
+    response_schema: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> TextGenerationTask:
+    return TextGenerationTask(
+        step=step,
+        system_prompt="system",
+        user_prompt="user",
+        response_schema=response_schema or {"ok": {"type": "boolean"}},
+        metadata=metadata or {},
+    )
+
+
+class _ProviderResponse:
+    def __init__(
+        self,
+        data: dict[str, Any] | None = None,
+        *,
+        status_code: int = 200,
+        text: str = "",
+        json_error: Exception | None = None,
+    ) -> None:
+        self._data = data or {}
+        self._json_error = json_error
+        self.status_code = status_code
+        self.text = text
+        self.request = httpx.Request("POST", "https://provider.test/generate")
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            response = httpx.Response(
+                self.status_code,
+                text=self.text,
+                request=self.request,
+            )
+            raise httpx.HTTPStatusError(
+                "provider error",
+                request=self.request,
+                response=response,
+            )
+
+    def json(self) -> dict[str, Any]:
+        if self._json_error is not None:
+            raise self._json_error
+        return self._data
+
+
+class _AsyncPostClient:
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = outcomes
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def post(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((args, kwargs))
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _dashscope_success_response(content: str) -> _ProviderResponse:
+    return _ProviderResponse(
+        {
+            "output": {
+                "choices": [
+                    {
+                        "message": {
+                            "content": content,
+                        }
+                    }
+                ]
+            }
+        }
+    )
+
+
+def _openai_success_response(content: str) -> _ProviderResponse:
+    return _ProviderResponse(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": content,
+                    }
+                }
+            ]
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_deterministic_provider_covers_supported_steps() -> None:
+    provider = DeterministicTextGenerationProvider()
+    cases = [
+        _task(
+            "bible",
+            metadata={
+                "premise": "A map changes at dawn.",
+                "genre": "fantasy",
+                "tone": "urgent",
+            },
+        ),
+        _task("outline", metadata={"target_chapters": 2}),
+        _task("chapter_scenes", metadata={"chapter_number": 3, "chapter_title": "Turn"}),
+        _task("semantic_review", metadata={"overdue_promise_count": 4}),
+        _task("semantic_review", metadata={"unresolved_hook_count": 3}),
+        _task("revision", metadata={"issues": []}),
+        _task("revision", metadata={"issues": [{"code": "flat"}]}),
+        _task(
+            "terminal_arc_revision",
+            metadata={
+                "target_chapters": 5,
+                "protagonist": "Ari",
+                "primary_keeper": "Lian",
+                "supporting_witness": "Kade",
+            },
+        ),
+        _task("unknown", metadata={"source": "fallback"}),
+    ]
+
+    results = [await provider.generate_structured(case) for case in cases]
+
+    assert all(isinstance(result, TextGenerationResult) for result in results)
+    assert results[0].content["world_bible"]["setting"].startswith("Fantasy")
+    assert len(results[1].content["chapters"]) == 2
+    assert results[2].content["scenes"][0]["scene_type"] == "opening"
+    assert results[3].content["semantic_score"] == 72
+    assert results[4].content["reader_pull_score"] == 68
+    assert results[5].content["revision_notes"] == ["No critical revisions required."]
+    assert "Align chapter timeline markers" in results[6].content["revision_notes"][0]
+    assert len(results[7].content["chapters"]) == 5
+    assert results[8].content == {"result": "ok", "step": "unknown", "echo": {"source": "fallback"}}
+
+
+def test_provider_factory_default_dashscope_without_key_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("APP_ENVIRONMENT", "testing")
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    provider = create_text_generation_provider(NovelEngineSettings())
+
+    assert isinstance(provider, UnconfiguredTextGenerationProvider)
+
+
+def test_provider_factory_rejects_unknown_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APP_ENVIRONMENT", "testing")
+    settings = NovelEngineSettings()
+
+    with pytest.raises(ValueError, match="Unsupported text generation provider"):
+        create_text_generation_provider(settings, provider_name=cast(Any, "bogus"))
+
+
+def test_provider_factory_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APP_ENVIRONMENT", "testing")
+    settings = NovelEngineSettings()
+
+    provider = create_text_generation_provider(
+        settings,
+        provider_name="mock",
+        model_name="test-model",
+    )
+    result = asyncio.run(provider.generate_structured(_task()))
+
+    assert result.model == "test-model"
+
+
+def test_openai_provider_requires_api_key() -> None:
+    with pytest.raises(ValueError, match="API key"):
+        OpenAICompatibleTextGenerationProvider(api_key="")
+
+
+def test_dashscope_provider_requires_api_key() -> None:
+    with pytest.raises(ValueError, match="DashScope API key"):
+        DashScopeTextGenerationProvider(api_key="")
+
+
+@pytest.mark.asyncio
+async def test_dashscope_provider_generates_structured_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(api_key="dashscope-key", retry_attempts=1)
+    fake_client = _AsyncPostClient(
+        [_dashscope_success_response('{"items": "single", "count": "2"}')]
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+
+    result = await provider.generate_structured(
+        _task(
+            response_schema={
+                "items": {"type": "array"},
+                "count": {"type": "integer"},
+            }
+        )
+    )
+
+    assert result.provider == "dashscope"
+    assert result.content == {"items": ["single"], "count": 2}
+    assert fake_client.calls[0][0] == (provider._endpoint_path(),)
+    assert fake_client.calls[0][1]["timeout"] == 60.0
+
+
+@pytest.mark.asyncio
+async def test_dashscope_provider_retries_timeout_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(
+        api_key="dashscope-key",
+        retry_attempts=2,
+        retry_delay=0,
+    )
+    fake_client = _AsyncPostClient(
+        [
+            httpx.ReadTimeout("slow"),
+            _dashscope_success_response('{"ok": true}'),
+        ]
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+
+    result = await provider.generate_structured(_task())
+
+    assert result.content == {"ok": True}
+    assert len(fake_client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_dashscope_provider_maps_http_status_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(api_key="dashscope-key", retry_attempts=1)
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _AsyncPostClient(
+            [_ProviderResponse(status_code=500, text="upstream failed")]
+        ),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match="500 upstream failed"):
+        await provider.generate_structured(_task())
+
+
+@pytest.mark.asyncio
+async def test_dashscope_provider_maps_json_decode_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(api_key="dashscope-key", retry_attempts=1)
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _AsyncPostClient(
+            [
+                _ProviderResponse(
+                    {"output": {}},
+                    json_error=json.JSONDecodeError("bad json", "not-json", 0),
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match="invalid JSON"):
+        await provider.generate_structured(_task())
+
+
+@pytest.mark.asyncio
+async def test_dashscope_provider_maps_non_json_object_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(api_key="dashscope-key", retry_attempts=1)
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _AsyncPostClient([_dashscope_success_response("[1, 2]")]),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match="not a JSON object"):
+        await provider.generate_structured(_task())
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "missing output"),
+        ({"output": {"choices": [1]}}, "choice is not an object"),
+        ({"output": {"choices": [{"message": "text"}]}}, "message is not an object"),
+        ({"output": {}}, "missing structured message content"),
+    ],
+)
+def test_dashscope_generation_response_shape_errors(
+    payload: dict[str, Any],
+    message: str,
+) -> None:
+    with pytest.raises(TextGenerationProviderError, match=message):
+        DashScopeTextGenerationProvider._extract_generation_response_text(payload)
+
+
+def test_dashscope_extracts_generation_content_list_and_text_fallback() -> None:
+    content_list = DashScopeTextGenerationProvider._extract_generation_response_text(
+        {"output": {"choices": [{"message": {"content": [{"text": "a"}, {"text": "b"}]}}]}}
+    )
+    text_fallback = DashScopeTextGenerationProvider._extract_generation_response_text(
+        {"output": {"text": "{\"ok\": true}"}}
+    )
+
+    assert content_list == "ab"
+    assert text_fallback == '{"ok": true}'
+
+
+def test_dashscope_responses_text_extraction_and_errors() -> None:
+    text = DashScopeTextGenerationProvider._extract_responses_text(
+        {
+            "output": [
+                {"type": "ignored"},
+                {"type": "message", "content": [{"text": "hello"}, {"text": " world"}]},
+            ]
+        }
+    )
+
+    assert text == "hello world"
+    with pytest.raises(TextGenerationProviderError, match="output is invalid"):
+        DashScopeTextGenerationProvider._extract_responses_text({"output": {}})
+    with pytest.raises(TextGenerationProviderError, match="missing message text"):
+        DashScopeTextGenerationProvider._extract_responses_text({"output": []})
+
+
+def test_dashscope_parse_json_nested_string_and_invalid_value() -> None:
+    assert DashScopeTextGenerationProvider._parse_json_object('"{\\"ok\\": true}"') == {
+        "ok": True
+    }
+
+    with pytest.raises(TextGenerationProviderError, match="not a JSON object"):
+        DashScopeTextGenerationProvider._parse_json_object("[]")
+
+
+def test_dashscope_retry_policy_boundaries() -> None:
+    assert DashScopeTextGenerationProvider._should_retry(
+        TextGenerationProviderError("invalid json")
+    )
+    assert DashScopeTextGenerationProvider._should_retry(
+        TextGenerationProviderError("timed out after 30s")
+    )
+    assert DashScopeTextGenerationProvider._should_retry(
+        TextGenerationProviderError("provider returned 429 too many requests")
+    )
+    assert not DashScopeTextGenerationProvider._should_retry(RuntimeError("boom"))
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_generates_structured_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAICompatibleTextGenerationProvider(api_key="openai-key")
+    fake_client = _AsyncPostClient([_openai_success_response('{"ok": true}')])
+    monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+
+    result = await provider.generate_structured(_task())
+
+    assert result.provider == "openai_compatible"
+    assert result.content == {"ok": True}
+    assert fake_client.calls[0][0] == ("/chat/completions",)
+    payload = fake_client.calls[0][1]["json"]
+    assert payload["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "missing choices"),
+        ({"choices": [1]}, "choice is not an object"),
+        ({"choices": [{"message": "text"}]}, "message is not an object"),
+        ({"choices": [{"message": {"content": "[1]"}}]}, "not a JSON object"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_maps_shape_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, Any],
+    message: str,
+) -> None:
+    provider = OpenAICompatibleTextGenerationProvider(api_key="openai-key")
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _AsyncPostClient([_ProviderResponse(payload)]),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match=message):
+        await provider.generate_structured(_task())
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_maps_http_and_json_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_provider = OpenAICompatibleTextGenerationProvider(api_key="openai-key")
+    monkeypatch.setattr(
+        status_provider,
+        "_get_client",
+        lambda: _AsyncPostClient([_ProviderResponse(status_code=401, text="nope")]),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match="401 nope"):
+        await status_provider.generate_structured(_task())
+
+    json_provider = OpenAICompatibleTextGenerationProvider(api_key="openai-key")
+    monkeypatch.setattr(
+        json_provider,
+        "_get_client",
+        lambda: _AsyncPostClient([_openai_success_response("not-json")]),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match="invalid JSON"):
+        await json_provider.generate_structured(_task())
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_provider_maps_transport_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAICompatibleTextGenerationProvider(api_key="openai-key")
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _AsyncPostClient([httpx.ReadTimeout("slow")]),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match="slow"):
+        await provider.generate_structured(_task())
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_provider_error_trips_circuit_breaker() -> None:
+    provider = UnconfiguredTextGenerationProvider(
+        provider_name="dashscope",
+        model="qwen3.5-flash",
+        message="DASHSCOPE_API_KEY is required",
+    )
+    breaker = CircuitBreaker(
+        "ai-provider",
+        CircuitBreakerConfig(failure_threshold=1),
+        expected_exception=TextGenerationProviderError,
+    )
+
+    async def _call_provider() -> None:
+        await provider.generate_structured(_task())
+
+    with pytest.raises(TextGenerationProviderError):
+        await breaker.call(_call_provider)
+    with pytest.raises(CircuitBreakerOpenError):
+        await breaker.call(_call_provider)

--- a/tests/shared/infrastructure/honcho/test_honcho_client.py
+++ b/tests/shared/infrastructure/honcho/test_honcho_client.py
@@ -1,0 +1,212 @@
+"""Mock-based contracts for the optional Honcho client wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from src.shared.infrastructure.honcho import HonchoClient, HonchoSettings
+from src.shared.infrastructure.honcho import client as client_module
+from src.shared.infrastructure.honcho.errors import HonchoClientError
+
+
+class _FakeHoncho:
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_honcho() -> None:
+    _FakeHoncho.calls.clear()
+
+
+@pytest.mark.asyncio
+async def test_client_lazy_initializes_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_module, "_Honcho", _FakeHoncho)
+    settings = HonchoSettings(
+        api_key="honcho-key",
+        base_url="http://honcho.local/",
+        timeout=5,
+    )
+
+    client = HonchoClient(settings)
+    assert _FakeHoncho.calls == []
+
+    first = await client._get_client()
+    second = await client._get_client()
+
+    assert first is second
+    assert _FakeHoncho.calls == [
+        {
+            "base_url": "http://honcho.local",
+            "timeout": 5,
+            "api_key": "honcho-key",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_honcho_package_maps_to_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_module, "_Honcho", None)
+    client = HonchoClient(HonchoSettings())
+
+    with pytest.raises(HonchoClientError) as exc_info:
+        await client._get_client()
+
+    assert exc_info.value.error_code == "HONCHO_PACKAGE_MISSING"
+    assert exc_info.value.details is not None
+    assert exc_info.value.details.operation == "initialize"
+
+
+@pytest.mark.asyncio
+async def test_cloud_deployment_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_module, "_Honcho", _FakeHoncho)
+    client = HonchoClient(HonchoSettings(deployment="cloud", api_key=None))
+
+    with pytest.raises(HonchoClientError, match="HONCHO_API_KEY") as exc_info:
+        await client._get_client()
+
+    assert exc_info.value.error_code == "CONFIGURATION_ERROR"
+    assert _FakeHoncho.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("factory_error", "error_code"),
+    [
+        (ConnectionError("network down"), "CONNECTION_ERROR"),
+        (TimeoutError("slow honcho"), "TIMEOUT_ERROR"),
+        (RuntimeError("boom"), "UNKNOWN_ERROR"),
+    ],
+)
+async def test_initialization_failures_map_to_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+    factory_error: Exception,
+    error_code: str,
+) -> None:
+    class _FailingHoncho:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+            raise factory_error
+
+    monkeypatch.setattr(client_module, "_Honcho", _FailingHoncho)
+    client = HonchoClient(HonchoSettings())
+
+    with pytest.raises(HonchoClientError) as exc_info:
+        await client._get_client()
+
+    assert exc_info.value.error_code == error_code
+    assert exc_info.value.details is not None
+    assert exc_info.value.details.original_exception is factory_error
+
+
+def test_settings_normalize_deployment_and_workspace_ids() -> None:
+    settings = HonchoSettings(
+        deployment="managed",
+        base_url="http://localhost:8000/",
+        default_workspace_name="novel",
+    )
+
+    assert settings.is_cloud
+    assert settings.base_url == "http://localhost:8000"
+    assert settings.get_workspace_id() == "novel"
+    assert settings.get_workspace_for_story("story-1") == "novel-story-1"
+    assert settings.get_workspace_for_character("char-1", "story-1") == "novel-story-1"
+
+
+def test_settings_character_strategy_uses_character_workspace() -> None:
+    settings = HonchoSettings(
+        default_workspace_name="novel",
+        workspace_strategy="character",
+    )
+
+    assert settings.is_self_hosted
+    assert settings.get_workspace_for_character("char-1", "story-1") == "novel-char-1"
+
+
+def test_settings_reject_invalid_deployment() -> None:
+    with pytest.raises(ValidationError):
+        HonchoSettings(deployment="invalid")
+
+
+@pytest.mark.asyncio
+async def test_health_check_false_when_initialization_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_module, "_Honcho", None)
+    client = HonchoClient(HonchoSettings())
+
+    assert await client.health_check() is False
+
+
+@pytest.mark.asyncio
+async def test_health_check_uses_boolean_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _ProbeHoncho:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        async def health(self) -> bool:
+            return True
+
+    monkeypatch.setattr(client_module, "_Honcho", _ProbeHoncho)
+    client = HonchoClient(HonchoSettings())
+
+    assert await client.health_check() is True
+
+
+@pytest.mark.asyncio
+async def test_health_check_uses_response_ok_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        ok = False
+
+    class _ProbeHoncho:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def ping(self) -> _Response:
+            return _Response()
+
+    monkeypatch.setattr(client_module, "_Honcho", _ProbeHoncho)
+    client = HonchoClient(HonchoSettings())
+
+    assert await client.health_check() is False
+
+
+@pytest.mark.asyncio
+async def test_health_check_fails_when_all_available_probes_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingProbeHoncho:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def health(self) -> bool:
+            raise RuntimeError("health endpoint down")
+
+        def status(self) -> bool:
+            raise RuntimeError("status endpoint down")
+
+    monkeypatch.setattr(client_module, "_Honcho", _FailingProbeHoncho)
+    client = HonchoClient(HonchoSettings())
+
+    assert await client.health_check() is False
+
+
+@pytest.mark.asyncio
+async def test_health_check_succeeds_without_probe_after_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_module, "_Honcho", _FakeHoncho)
+    client = HonchoClient(HonchoSettings())
+
+    assert await client.health_check() is True

--- a/tests/shared/infrastructure/honcho/test_honcho_health_check.py
+++ b/tests/shared/infrastructure/honcho/test_honcho_health_check.py
@@ -1,0 +1,101 @@
+"""Honcho health-check status contracts."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from src.shared.infrastructure.health.checks.honcho_health_check import (
+    HonchoHealthCheck,
+)
+from src.shared.infrastructure.health.health_checker import HealthStatus
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_reports_not_configured() -> None:
+    status = await HonchoHealthCheck().check()
+
+    assert status.status == "unknown"
+    assert status.message == "Honcho client not configured"
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_reports_healthy() -> None:
+    class _Client:
+        async def health_check(self) -> bool:
+            return True
+
+    status = await HonchoHealthCheck(cast(Any, _Client())).check()
+
+    assert status.status == "healthy"
+    assert status.message == "Honcho service connection successful"
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_reports_unhealthy() -> None:
+    class _Client:
+        async def health_check(self) -> bool:
+            return False
+
+    status = await HonchoHealthCheck(cast(Any, _Client())).check()
+
+    assert status.status == "unhealthy"
+    assert status.message == "Honcho service health check failed"
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_preserves_degraded_result() -> None:
+    class _Client:
+        async def health_check(self) -> HealthStatus:
+            return HealthStatus(status="degraded", message="Honcho latency is high")
+
+    status = await HonchoHealthCheck(cast(Any, _Client())).check()
+
+    assert status.status == "degraded"
+    assert status.message == "Honcho latency is high"
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_supports_string_status() -> None:
+    class _Client:
+        def health_check(self) -> str:
+            return "degraded"
+
+    status = await HonchoHealthCheck(cast(Any, _Client())).check()
+
+    assert status.status == "degraded"
+    assert status.message == "Honcho service reported degraded"
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_falls_back_to_get_client() -> None:
+    class _Client:
+        async def _get_client(self) -> object:
+            return object()
+
+    status = await HonchoHealthCheck(cast(Any, _Client())).check()
+
+    assert status.status == "healthy"
+    assert status.message == "Honcho client initialized successfully"
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_reports_missing_probe() -> None:
+    status = await HonchoHealthCheck(cast(Any, object())).check()
+
+    assert status.status == "unknown"
+    assert status.message == "Honcho client does not expose a health probe"
+
+
+@pytest.mark.asyncio
+async def test_honcho_health_check_reports_exception_details() -> None:
+    class _Client:
+        async def health_check(self) -> bool:
+            raise TimeoutError("probe timed out")
+
+    status = await HonchoHealthCheck(cast(Any, _Client())).check()
+
+    assert status.status == "unhealthy"
+    assert status.error == "probe timed out"
+    assert status.details == {"error_type": "TimeoutError"}

--- a/tests/shared/infrastructure/honcho/test_honcho_managers.py
+++ b/tests/shared/infrastructure/honcho/test_honcho_managers.py
@@ -1,0 +1,333 @@
+"""Mocked Honcho manager behavior and error-mapping tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.shared.infrastructure.honcho import HonchoSettings
+from src.shared.infrastructure.honcho.errors import HonchoClientError
+from src.shared.infrastructure.honcho.message_handler import HonchoMessageHandler
+from src.shared.infrastructure.honcho.session_manager import HonchoSessionManager
+from src.shared.infrastructure.honcho.workspace_manager import HonchoWorkspaceManager
+
+
+class _AsyncCall:
+    def __init__(self, result: Any = None, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((args, kwargs))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _Context:
+    def to_openai(self) -> list[dict[str, Any]]:
+        return [{"role": "user", "content": "hello"}]
+
+
+def _classify_error(error: Exception) -> str:
+    if isinstance(error, ConnectionError):
+        return "CONNECTION_ERROR"
+    if isinstance(error, TimeoutError):
+        return "TIMEOUT_ERROR"
+    if isinstance(error, HonchoClientError):
+        return error.error_code
+    return "UNKNOWN_ERROR"
+
+
+def _workspace_manager(client: Any) -> HonchoWorkspaceManager:
+    async def _get_client() -> Any:
+        return client
+
+    return HonchoWorkspaceManager(_get_client, _classify_error)
+
+
+def _session_manager(client: Any) -> HonchoSessionManager:
+    async def _get_client() -> Any:
+        return client
+
+    return HonchoSessionManager(_get_client, _classify_error)
+
+
+def _message_handler(client: Any) -> HonchoMessageHandler:
+    async def _get_client() -> Any:
+        return client
+
+    return HonchoMessageHandler(_get_client, _classify_error, HonchoSettings())
+
+
+@pytest.mark.asyncio
+async def test_workspace_manager_returns_existing_workspace() -> None:
+    workspace = object()
+    get = _AsyncCall(workspace)
+    create = _AsyncCall(object())
+    client = SimpleNamespace(workspaces=SimpleNamespace(get=get, create=create))
+
+    result = await _workspace_manager(client).get_or_create_workspace("story-1")
+
+    assert result is workspace
+    assert get.calls == [(("story-1",), {})]
+    assert create.calls == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_manager_creates_missing_workspace() -> None:
+    workspace = object()
+    get = _AsyncCall(None)
+    create = _AsyncCall(workspace)
+    client = SimpleNamespace(workspaces=SimpleNamespace(get=get, create=create))
+
+    result = await _workspace_manager(client).get_or_create_workspace("story-1")
+
+    assert result is workspace
+    assert create.calls == [
+        ((), {"workspace_id": "story-1", "name": "story-1"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workspace_manager_maps_get_and_create_errors() -> None:
+    get_error = RuntimeError("broken get")
+    client = SimpleNamespace(
+        workspaces=SimpleNamespace(get=_AsyncCall(error=get_error), create=_AsyncCall())
+    )
+
+    with pytest.raises(HonchoClientError) as get_exc:
+        await _workspace_manager(client).get_or_create_workspace("story-1")
+
+    assert get_exc.value.error_code == "UNKNOWN_ERROR"
+    assert get_exc.value.details is not None
+    assert get_exc.value.details.operation == "get_workspace"
+
+    create_error = TimeoutError("slow create")
+    client = SimpleNamespace(
+        workspaces=SimpleNamespace(get=_AsyncCall(None), create=_AsyncCall(error=create_error))
+    )
+
+    with pytest.raises(HonchoClientError) as create_exc:
+        await _workspace_manager(client).get_or_create_workspace("story-1")
+
+    assert create_exc.value.error_code == "TIMEOUT_ERROR"
+    assert create_exc.value.details is not None
+    assert create_exc.value.details.operation == "create_workspace"
+
+
+@pytest.mark.asyncio
+async def test_workspace_manager_gets_or_creates_peer() -> None:
+    peer = object()
+    get = _AsyncCall(None)
+    create = _AsyncCall(peer)
+    client = SimpleNamespace(peers=SimpleNamespace(get=get, create=create))
+
+    result = await _workspace_manager(client).get_or_create_peer("story-1", "peer-1")
+
+    assert result is peer
+    assert get.calls == [(("story-1", "peer-1"), {})]
+    assert create.calls == [
+        ((), {"workspace_id": "story-1", "peer_id": "peer-1", "name": "peer-1"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workspace_manager_maps_peer_errors() -> None:
+    get_error = RuntimeError("peer get failed")
+    client = SimpleNamespace(
+        peers=SimpleNamespace(get=_AsyncCall(error=get_error), create=_AsyncCall())
+    )
+
+    with pytest.raises(HonchoClientError) as get_exc:
+        await _workspace_manager(client).get_or_create_peer("story-1", "peer-1")
+
+    assert get_exc.value.details is not None
+    assert get_exc.value.details.operation == "get_peer"
+
+    create_error = ConnectionError("peer create failed")
+    client = SimpleNamespace(
+        peers=SimpleNamespace(get=_AsyncCall(None), create=_AsyncCall(error=create_error))
+    )
+
+    with pytest.raises(HonchoClientError) as create_exc:
+        await _workspace_manager(client).get_or_create_peer("story-1", "peer-1")
+
+    assert create_exc.value.error_code == "CONNECTION_ERROR"
+    assert create_exc.value.details is not None
+    assert create_exc.value.details.operation == "create_peer"
+
+
+@pytest.mark.asyncio
+async def test_session_manager_creates_session_and_context() -> None:
+    session = object()
+    create = _AsyncCall(session)
+    context = _AsyncCall(_Context())
+    client = SimpleNamespace(sessions=SimpleNamespace(create=create, context=context))
+    manager = _session_manager(client)
+
+    created = await manager.create_session(
+        "story-1",
+        "peer-1",
+        session_id="session-1",
+        metadata={"kind": "test"},
+    )
+    openai_context = await manager.get_session_context("story-1", "session-1")
+
+    assert created is session
+    assert create.calls == [
+        (
+            (),
+            {
+                "workspace_id": "story-1",
+                "peer_id": "peer-1",
+                "session_id": "session-1",
+                "metadata": {"kind": "test"},
+            },
+        )
+    ]
+    assert openai_context == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_session_manager_maps_errors_and_empty_context() -> None:
+    create_error = TimeoutError("session timeout")
+    client = SimpleNamespace(
+        sessions=SimpleNamespace(
+            create=_AsyncCall(error=create_error),
+            context=_AsyncCall(SimpleNamespace()),
+        )
+    )
+    manager = _session_manager(client)
+
+    with pytest.raises(HonchoClientError) as create_exc:
+        await manager.create_session("story-1", "peer-1")
+
+    assert create_exc.value.error_code == "TIMEOUT_ERROR"
+    assert create_exc.value.details is not None
+    assert create_exc.value.details.operation == "create_session"
+
+    assert await manager.get_session_context("story-1", "session-1") == []
+
+    context_error = RuntimeError("context failed")
+    client.sessions.context = _AsyncCall(error=context_error)
+    with pytest.raises(HonchoClientError) as context_exc:
+        await manager.get_session_context("story-1", "session-1")
+
+    assert context_exc.value.error_code == "UNKNOWN_ERROR"
+    assert context_exc.value.details is not None
+    assert context_exc.value.details.operation == "get_session_context"
+
+
+@pytest.mark.asyncio
+async def test_message_handler_adds_and_searches_messages() -> None:
+    message = object()
+    search_result = [object()]
+    add = _AsyncCall(message)
+    session_search = _AsyncCall(search_result)
+    peer_search = _AsyncCall("unexpected shape")
+    client = SimpleNamespace(
+        messages=SimpleNamespace(create=add),
+        sessions=SimpleNamespace(search=session_search),
+        peers=SimpleNamespace(search=peer_search),
+    )
+    handler = _message_handler(client)
+
+    added = await handler.add_message("story-1", "session-1", "hello")
+    session_results = await handler.search_memories(
+        "story-1",
+        "peer-1",
+        "query",
+        session_id="session-1",
+    )
+    peer_results = await handler.search_memories("story-1", "peer-1", "query")
+
+    assert added is message
+    assert session_results == search_result
+    assert peer_results == []
+    assert add.calls[0][1]["metadata"] == {}
+    assert session_search.calls[0][1]["top_k"] == 10
+    assert peer_search.calls[0][1]["peer_id"] == "peer-1"
+
+
+@pytest.mark.asyncio
+async def test_message_handler_representation_and_chat_paths() -> None:
+    session_representation = _AsyncCall(SimpleNamespace(content="session insight"))
+    peer_representation = _AsyncCall(None)
+    session_chat = _AsyncCall(SimpleNamespace(content="session answer"))
+    peer_chat = _AsyncCall(SimpleNamespace(content="peer answer"))
+    client = SimpleNamespace(
+        sessions=SimpleNamespace(
+            representation=session_representation,
+            chat=session_chat,
+        ),
+        peers=SimpleNamespace(
+            representation=peer_representation,
+            chat=peer_chat,
+        ),
+    )
+    handler = _message_handler(client)
+
+    assert (
+        await handler.get_peer_representation("story-1", "peer-1", "session-1")
+        == "session insight"
+    )
+    assert await handler.get_peer_representation("story-1", "peer-1") == ""
+    assert await handler.chat_with_peer("story-1", "peer-1", "query", "session-1") == (
+        "session answer"
+    )
+    assert await handler.chat_with_peer("story-1", "peer-1", "query") == "peer answer"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "expected_code"),
+    [
+        ("add_message", "CONNECTION_ERROR"),
+        ("search_memories", "TIMEOUT_ERROR"),
+        ("get_peer_representation", "UNKNOWN_ERROR"),
+        ("chat_with_peer", "UNKNOWN_ERROR"),
+    ],
+)
+async def test_message_handler_maps_operation_errors(
+    operation: str,
+    expected_code: str,
+) -> None:
+    error_by_operation = {
+        "add_message": ConnectionError("add failed"),
+        "search_memories": TimeoutError("search failed"),
+        "get_peer_representation": RuntimeError("representation failed"),
+        "chat_with_peer": RuntimeError("chat failed"),
+    }
+    error = error_by_operation[operation]
+    client = SimpleNamespace(
+        messages=SimpleNamespace(create=_AsyncCall(error=error)),
+        sessions=SimpleNamespace(
+            search=_AsyncCall(error=error),
+            representation=_AsyncCall(error=error),
+            chat=_AsyncCall(error=error),
+        ),
+        peers=SimpleNamespace(
+            search=_AsyncCall(error=error),
+            representation=_AsyncCall(error=error),
+            chat=_AsyncCall(error=error),
+        ),
+    )
+    handler = _message_handler(client)
+
+    with pytest.raises(HonchoClientError) as exc_info:
+        if operation == "add_message":
+            await handler.add_message("story-1", "session-1", "hello")
+        elif operation == "search_memories":
+            await handler.search_memories("story-1", "peer-1", "query", session_id="s")
+        elif operation == "get_peer_representation":
+            await handler.get_peer_representation("story-1", "peer-1", "s")
+        else:
+            await handler.chat_with_peer("story-1", "peer-1", "query", "s")
+
+    assert exc_info.value.error_code == expected_code
+    assert exc_info.value.details is not None
+    assert exc_info.value.details.operation == operation


### PR DESCRIPTION
## Summary

This PR hardens the backend external-service boundary for optional Honcho infrastructure and AI/text-generation providers without changing business APIs or story semantics.

It adds mock-only unit coverage for Honcho client initialization, optional package/config failures, manager error mapping, and health-check status paths. It also expands AI provider coverage across factory selection, deterministic mock output, DashScope/OpenAI-compatible success and failure mapping, retry/timeout behavior, and circuit-breaker boundaries.

## Governance

Default PR CI remains free of live Honcho and DashScope credentials. Live Honcho smoke and DashScope contracts stay opt-in through `ENABLE_HONCHO_TESTS=1` and `ENABLE_DASHSCOPE_TESTS=1` with the relevant credentials.

## CI / docs

- Adds a focused Honcho + AI provider coverage gate at 80%.
- Mirrors the gate in `Makefile` and README local validation commands.
- Documents the mock-by-default provider testing model and live opt-in boundary.

## Verification

- `uv run pytest tests/shared/infrastructure/honcho tests/contexts/ai -q` -> 76 passed, 1 skipped
- `uv run pytest tests/shared/infrastructure/honcho tests/contexts/ai --cov=src/shared/infrastructure/honcho --cov=src.shared.infrastructure.health.checks.honcho_health_check --cov=src/contexts/ai/infrastructure/providers --cov-report=term-missing --cov-fail-under=80 -q` -> 91.25% coverage, 76 passed, 1 skipped
- `uv run ruff check src tests scripts` -> passed
- `uv run mypy src tests --no-error-summary --show-column-numbers` -> passed
- `uv run pytest -q` -> 631 passed, 76 skipped
- `uv run lint-imports` -> passed
- `uv run python scripts/qa/check_openapi_snapshot.py` -> snapshot up to date
- `uv run python scripts/qa/run_api_public_audit.py` -> 53/53 checks, 100% route coverage