### PR TITLE
fix: coerce DashScope sidecar schema fields

### DIFF
--- a/src/contexts/ai/infrastructure/providers/dashscope_text_generation_provider.py
+++ b/src/contexts/ai/infrastructure/providers/dashscope_text_generation_provider.py
@@ -88,7 +88,19 @@ def _coerce_value_to_schema(
     expected_type = schema.get("type")
     if expected_type == "object":
         if isinstance(value, dict):
-            return value
+            properties = schema.get("properties")
+            if not isinstance(properties, dict):
+                return value
+            normalized = dict(value)
+            for nested_key, nested_schema in properties.items():
+                if nested_key not in normalized:
+                    continue
+                normalized[nested_key] = _coerce_value_to_schema(
+                    normalized[nested_key],
+                    nested_schema,
+                    key=str(nested_key),
+                )
+            return normalized
         if isinstance(value, list):
             if key == "character_bible":
                 return {"characters": value}
@@ -105,6 +117,16 @@ def _coerce_value_to_schema(
         return [value]
 
     if expected_type == "string":
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value.strip()
+        if isinstance(value, list):
+            return " ".join(
+                str(item).strip() for item in value if str(item).strip()
+            ).strip()
+        if isinstance(value, dict):
+            return json.dumps(value, ensure_ascii=False).strip()
         return str(value).strip()
 
     if expected_type == "integer":

--- a/tests/contexts/ai/infrastructure/test_text_generation_providers.py
+++ b/tests/contexts/ai/infrastructure/test_text_generation_providers.py
@@ -234,6 +234,53 @@ async def test_dashscope_provider_generates_structured_payload(
 
 
 @pytest.mark.asyncio
+async def test_dashscope_provider_coerces_nested_sidecar_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(api_key="dashscope-key", retry_attempts=1)
+    fake_client = _AsyncPostClient(
+        [
+            _dashscope_success_response(
+                json.dumps(
+                    {
+                        "chapter_markdown": "# Chapter 1\n\nA courier waits.",
+                        "sidecar_metadata": {
+                            "summary": ["A courier waits."],
+                            "characters": "Mira",
+                            "promises": None,
+                        },
+                    }
+                )
+            )
+        ]
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+
+    result = await provider.generate_structured(
+        _task(
+            step="chapter_draft",
+            response_schema={
+                "chapter_markdown": {"type": "string"},
+                "sidecar_metadata": {
+                    "type": "object",
+                    "properties": {
+                        "summary": {"type": "string"},
+                        "characters": {"type": "array"},
+                        "promises": {"type": "array"},
+                    },
+                },
+            },
+        )
+    )
+
+    assert result.content["sidecar_metadata"] == {
+        "summary": "A courier waits.",
+        "characters": ["Mira"],
+        "promises": [],
+    }
+
+
+@pytest.mark.asyncio
 async def test_dashscope_provider_retries_timeout_then_succeeds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/text_generation_contract_support.py
+++ b/tests/text_generation_contract_support.py
@@ -23,6 +23,20 @@ CONTRACT_STORY_PREMISE: Final[str] = (
 TextGenerationContractCase = tuple[str, TextGenerationTask]
 
 
+def _chapter_response_schema() -> dict[str, Any]:
+    return {
+        "chapter_markdown": {"type": "string"},
+        "sidecar_metadata": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string"},
+                "characters": {"type": "array"},
+                "promises": {"type": "array"},
+            },
+        },
+    }
+
+
 def build_contract_cases() -> list[TextGenerationContractCase]:
     """Build the canonical structured tasks used across provider tests."""
     draft_task = TextGenerationTask(
@@ -37,10 +51,7 @@ def build_contract_cases() -> list[TextGenerationContractCase]:
             f"Premise: {CONTRACT_STORY_PREMISE}\n"
             "Chapter number: 1"
         ),
-        response_schema={
-            "chapter_markdown": {"type": "string"},
-            "sidecar_metadata": {"type": "object"},
-        },
+        response_schema=_chapter_response_schema(),
         temperature=0.6,
         metadata={
             "title": CONTRACT_STORY_TITLE,
@@ -65,10 +76,7 @@ def build_contract_cases() -> list[TextGenerationContractCase]:
             "Current chapter: A thin scene needs a stronger emotional turn.\n"
             "Brief: rewrite the complete chapter as natural prose."
         ),
-        response_schema={
-            "chapter_markdown": {"type": "string"},
-            "sidecar_metadata": {"type": "object"},
-        },
+        response_schema=_chapter_response_schema(),
         temperature=0.45,
         metadata={
             "title": CONTRACT_STORY_TITLE,


### PR DESCRIPTION
## Summary
- recursively coerce DashScope object properties declared in response schemas
- normalize non-string sidecar summaries into readable strings
- update the provider contract schema and add a regression test for nested sidecar coercion

## Verification
- uv run pytest -q tests/contexts/ai/infrastructure/test_text_generation_providers.py tests/contract/test_text_generation_provider_contract.py tests/apps/api/test_workspaces.py tests/apps/cli/test_novel_engine.py tests/scripts/test_run_dashscope_longform_uat.py
- uv run ruff check src tests
- uv run mypy src tests --no-error-summary --show-column-numbers
- pre-push hook passed