### PR TITLE
fix: accept DashScope non-object chapter responses

### DIFF
--- a/src/contexts/ai/infrastructure/providers/dashscope_text_generation_provider.py
+++ b/src/contexts/ai/infrastructure/providers/dashscope_text_generation_provider.py
@@ -519,9 +519,44 @@ class DashScopeTextGenerationProvider(TextGenerationProvider):
             if nested is None or nested == parsed:
                 return None
             return DashScopeTextGenerationProvider._coerce_parsed_object_candidate(nested)
-        if isinstance(parsed, list) and len(parsed) == 1:
-            return DashScopeTextGenerationProvider._coerce_parsed_object_candidate(parsed[0])
+        if isinstance(parsed, list):
+            objects: list[dict[str, Any]] = []
+            for item in parsed:
+                normalized = (
+                    DashScopeTextGenerationProvider._coerce_parsed_object_candidate(item)
+                )
+                if normalized is not None:
+                    objects.append(normalized)
+            if not objects:
+                return None
+            merged: dict[str, Any] = {}
+            for item in objects:
+                merged.update(item)
+            return merged
         return None
+
+    @staticmethod
+    def _fallback_payload_from_non_object_response(
+        raw_text: str,
+        response_schema: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        chapter_schema = response_schema.get("chapter_markdown")
+        if not isinstance(chapter_schema, dict) or chapter_schema.get("type") != "string":
+            return None
+
+        parsed = DashScopeTextGenerationProvider._parse_json_like_value(raw_text.strip())
+        if isinstance(parsed, str):
+            markdown = parsed.strip()
+        elif isinstance(parsed, list):
+            markdown = "\n\n".join(
+                item.strip() for item in parsed if isinstance(item, str) and item.strip()
+            ).strip()
+        else:
+            markdown = raw_text.strip()
+
+        if not markdown:
+            return None
+        return {"chapter_markdown": markdown}
 
     async def generate_structured(
         self,
@@ -540,10 +575,17 @@ class DashScopeTextGenerationProvider(TextGenerationProvider):
                 response.raise_for_status()
                 data = response.json()
                 content_text = self._transport.extract_response_text(data)
-                parsed = _coerce_payload_to_schema(
-                    self._parse_json_object(content_text),
-                    task.response_schema,
-                )
+                try:
+                    payload = self._parse_json_object(content_text)
+                except TextGenerationProviderError as exc:
+                    fallback_payload = self._fallback_payload_from_non_object_response(
+                        content_text,
+                        task.response_schema,
+                    )
+                    if fallback_payload is None:
+                        raise exc
+                    payload = fallback_payload
+                parsed = _coerce_payload_to_schema(payload, task.response_schema)
                 return TextGenerationResult(
                     step=task.step,
                     provider="dashscope",

--- a/tests/contexts/ai/infrastructure/test_text_generation_providers.py
+++ b/tests/contexts/ai/infrastructure/test_text_generation_providers.py
@@ -357,6 +357,69 @@ async def test_dashscope_provider_maps_non_json_object_response(
         await provider.generate_structured(_task())
 
 
+@pytest.mark.asyncio
+async def test_dashscope_provider_uses_chapter_text_fallback_for_non_object_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(api_key="dashscope-key", retry_attempts=1)
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _AsyncPostClient(
+            [
+                _dashscope_success_response(
+                    json.dumps(
+                        [
+                            "# Chapter 1: The Bell Debt",
+                            "Mira follows the sound into the counting room.",
+                        ]
+                    )
+                )
+            ]
+        ),
+    )
+
+    result = await provider.generate_structured(
+        _task(
+            "chapter_draft",
+            response_schema={
+                "chapter_markdown": {"type": "string"},
+                "sidecar_metadata": {"type": "object"},
+            },
+        )
+    )
+
+    assert result.content == {
+        "chapter_markdown": (
+            "# Chapter 1: The Bell Debt\n\n"
+            "Mira follows the sound into the counting room."
+        )
+    }
+
+
+@pytest.mark.asyncio
+async def test_dashscope_provider_rejects_non_text_chapter_array(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = DashScopeTextGenerationProvider(api_key="dashscope-key", retry_attempts=1)
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _AsyncPostClient([_dashscope_success_response("[1, 2]")]),
+    )
+
+    with pytest.raises(TextGenerationProviderError, match="not a JSON object"):
+        await provider.generate_structured(
+            _task(
+                "chapter_draft",
+                response_schema={
+                    "chapter_markdown": {"type": "string"},
+                    "sidecar_metadata": {"type": "object"},
+                },
+            )
+        )
+
+
 @pytest.mark.parametrize(
     ("payload", "message"),
     [
@@ -410,6 +473,18 @@ def test_dashscope_parse_json_nested_string_and_invalid_value() -> None:
 
     with pytest.raises(TextGenerationProviderError, match="not a JSON object"):
         DashScopeTextGenerationProvider._parse_json_object("[]")
+
+
+def test_dashscope_parse_json_merges_objects_from_array_wrapper() -> None:
+    parsed = DashScopeTextGenerationProvider._parse_json_object(
+        '["{\\"chapter_markdown\\": \\"# Chapter 1\\"}", '
+        '"{\\"sidecar_metadata\\": {\\"summary\\": \\"A bell rings.\\"}}"]'
+    )
+
+    assert parsed == {
+        "chapter_markdown": "# Chapter 1",
+        "sidecar_metadata": {"summary": "A bell rings."},
+    }
 
 
 def test_dashscope_retry_policy_boundaries() -> None:


### PR DESCRIPTION
## Summary
- merge recursively parsed object fragments from DashScope array wrappers
- add a chapter-only fallback for non-object text/array-of-text responses when the schema requires `chapter_markdown`
- keep non-text arrays and non-chapter schemas failing as provider errors

## Verification
- `uv run pytest -q tests/contexts/ai/infrastructure/test_text_generation_providers.py tests/contexts/ai/infrastructure/test_provider_factory.py tests/contract/test_text_generation_provider_contract.py tests/apps/cli/test_novel_engine.py tests/scripts/test_run_dashscope_longform_uat.py`
- `uv run ruff check src tests`
- `uv run mypy src tests --no-error-summary --show-column-numbers`
- pre-push hook passed, including backend pytest and frontend type-check/test/build/e2e/audits

## Live UAT Context
Run `27111157392` reached the longform drafting flow and failed at `poll_run_job` with `DashScope response is not a JSON object`. This PR keeps structured tasks strict, but allows chapter drafting to recover from provider responses that arrive as text or string arrays.