### PR TITLE
fix: fall back when editorial provider review fails

### DIFF
--- a/src/contexts/narrative/application/services/local_writing_engine.py
+++ b/src/contexts/narrative/application/services/local_writing_engine.py
@@ -887,10 +887,13 @@ class EditorialJudge:
         fallback = self.deterministic_suggestions(chapters, sidecars)
         if self._provider is None or not fallback:
             return fallback
-        result = await self._provider.generate_structured(
-            self._review_task(workspace, chapters, sidecars)
-        )
-        return self._issues_from_provider(result.content, fallback)
+        try:
+            result = await self._provider.generate_structured(
+                self._review_task(workspace, chapters, sidecars)
+            )
+            return self._issues_from_provider(result.content, fallback)
+        except Exception:
+            return fallback
 
     def deterministic_suggestions(
         self,

--- a/tests/apps/api/test_workspaces.py
+++ b/tests/apps/api/test_workspaces.py
@@ -371,7 +371,7 @@ def test_explicit_unconfigured_real_provider_is_rejected(
     assert "Provider is not configured" in response.json()["error"]["message"]
 
 
-def test_configured_real_provider_review_failure_fails_job(
+def test_configured_real_provider_review_failure_uses_fallback(
     canonical_client: Any,
     monkeypatch: Any,
 ) -> None:
@@ -412,10 +412,17 @@ def test_configured_real_provider_review_failure_fails_job(
 
     assert response.status_code == 202
     job = _wait_for_job(canonical_client, "salt-ledger", str(response.json()["job_id"]))
-    assert job["status"] == "failed"
-    assert "judge failed under" in job["error"]
-    assert str(get_settings().data_dir).replace("\\", "/") not in job["error"].replace("\\", "/")
-    assert job["failure_artifact"]["relative_path"].startswith("artifacts/jobs/")
+    assert job["status"] == "completed"
+    assert job["error"] is None
+    suggestions = job["result"]["review"]["suggestions"]
+    assert {item["code"] for item in suggestions} == {
+        "agency_attribution",
+        "causal_continuity",
+        "reader_pull",
+        "closure_spacing",
+        "promise_trust",
+        "voice_stability",
+    }
 
 
 def test_export_preserves_existing_editorial_review(canonical_client: Any) -> None:

--- a/tests/apps/cli/test_novel_engine.py
+++ b/tests/apps/cli/test_novel_engine.py
@@ -9,6 +9,7 @@ import pytest
 
 from src.apps.cli.novel_engine import main
 from src.contexts.ai.application.ports.text_generation_port import (
+    TextGenerationProviderError,
     TextGenerationResult,
     TextGenerationTask,
 )
@@ -66,6 +67,16 @@ class MechanicalPhraseProvider:
             model="mechanical-phrase-fixture",
             raw_text=json.dumps(payload, ensure_ascii=False),
             content=payload,
+        )
+
+
+class FailingEditorialProvider:
+    async def generate_structured(
+        self,
+        task: TextGenerationTask,
+    ) -> TextGenerationResult:
+        raise TextGenerationProviderError(
+            f"provider failed for {task.step}: not a JSON object"
         )
 
 
@@ -166,6 +177,29 @@ def test_review_warnings_do_not_block_export(tmp_path: Path) -> None:
     exported = LocalExporter().export_markdown(workspace)
     assert exported.exists()
     assert "# The Salt Ledger" in exported.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_review_async_falls_back_when_editorial_provider_fails(
+    tmp_path: Path,
+) -> None:
+    workspace = build_workspace(tmp_path)
+    await LocalDraftingEngine(DeterministicTextGenerationProvider()).draft_chapter(
+        workspace,
+        1,
+    )
+
+    report = await LocalReviewer(FailingEditorialProvider()).review_async(workspace)
+
+    assert report.blockers == []
+    assert {issue.code for issue in report.suggestions} == {
+        "agency_attribution",
+        "causal_continuity",
+        "reader_pull",
+        "closure_spacing",
+        "promise_trust",
+        "voice_stability",
+    }
 
 
 def test_review_blocks_empty_chapter_export(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make provider-backed editorial review non-blocking by returning deterministic suggestions when provider review fails
- update API behavior so configured provider review failures complete with fallback review output instead of failing the job
- add CLI/API regression coverage for provider review fallback

## Verification
- `uv run pytest -q tests/apps/cli/test_novel_engine.py tests/apps/api/test_workspaces.py tests/scripts/test_run_dashscope_longform_uat.py tests/contract/test_text_generation_provider_contract.py tests/contexts/ai/infrastructure/test_text_generation_providers.py`
- `uv run ruff check src tests`
- `uv run mypy src tests --no-error-summary --show-column-numbers`
- pre-push hook passed, including backend pytest and frontend type-check/test/build/e2e/audits

## Live UAT Context
Run `27111549204` still failed with `DashScope response is not a JSON object` after chapter response fallback landed. The failure happened late in the run flow, consistent with provider-backed editorial review. Editorial provider output is advice-only, so this PR keeps run/export progress on deterministic review when that provider call is malformed.