### PR TITLE
fix: guard chapter surface cleanup before review

### DIFF
--- a/src/contexts/narrative/application/services/local_writing_engine.py
+++ b/src/contexts/narrative/application/services/local_writing_engine.py
@@ -855,7 +855,7 @@ class LocalDraftingEngine:
         )
 
     def _validate_chapter_surface(self, markdown: str) -> None:
-        lowered = markdown.lower()
+        lowered = _sanitize_chapter_markdown(markdown).lower()
         for phrase in FORBIDDEN_TEMPLATE_PHRASES:
             if phrase.lower() in lowered:
                 raise ValueError(f"Chapter prose contains forbidden phrase: {phrase}")
@@ -1225,6 +1225,10 @@ class LocalReviewer:
 
         for path in chapters:
             text = path.read_text(encoding="utf-8").strip()
+            cleaned_text = _sanitize_chapter_markdown(text)
+            if cleaned_text != text:
+                _atomic_write_text(path, cleaned_text + "\n")
+                text = cleaned_text
             location = path.stem
             word_count = len(text.split())
             if not text:

--- a/tests/apps/cli/test_novel_engine.py
+++ b/tests/apps/cli/test_novel_engine.py
@@ -179,6 +179,25 @@ def test_review_warnings_do_not_block_export(tmp_path: Path) -> None:
     assert "# The Salt Ledger" in exported.read_text(encoding="utf-8")
 
 
+def test_review_sanitizes_mechanical_phrases_before_blocker_check(
+    tmp_path: Path,
+) -> None:
+    workspace = build_workspace(tmp_path)
+    workspace.write_chapter(
+        1,
+        "# Chapter 1: The Bell Debt\n\n"
+        "Here is the first draft of the rewritten chapter.\n\n"
+        "Mira followed the bell through the flooded arcade while every shopkeeper "
+        "pretended not to hear it. The chapter closes with Mira stepping into the "
+        "counting room.",
+    )
+
+    report = LocalReviewer().review(workspace)
+
+    assert report.blockers == []
+    assert_no_mechanical_prose(workspace.read_chapter(1))
+
+
 @pytest.mark.asyncio
 async def test_review_async_falls_back_when_editorial_provider_fails(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- validate chapter surface against sanitized manuscript text
- sanitize existing chapter files during review before mechanical blocker checks
- add regression coverage for already-written mechanical phrases being cleaned before review

## Verification
- `uv run pytest -q tests/apps/cli/test_novel_engine.py tests/apps/api/test_workspaces.py tests/scripts/test_run_dashscope_longform_uat.py tests/contract/test_text_generation_provider_contract.py tests/contexts/ai/infrastructure/test_text_generation_providers.py`
- `uv run ruff check src tests`
- `uv run mypy src tests --no-error-summary --show-column-numbers`
- pre-push hook passed, including backend pytest and frontend type-check/test/build/e2e/audits

## Live UAT Context
Run `27111918053` progressed past provider response/review fallback work and failed later with `Chapter prose contains forbidden phrase: first draft`. This PR adds a guard so review/hard checks clean already-written chapter files before treating mechanical phrases as blockers.