### PR TITLE
fix: harden DashScope longform live UAT retries

### DIFF
--- a/scripts/uat/run_dashscope_longform_uat.py
+++ b/scripts/uat/run_dashscope_longform_uat.py
@@ -118,6 +118,8 @@ class LongformUatFailureReport:
     failed_step: str
     error_message: str
     request_trace: list[RequestTrace]
+    job_payload: dict[str, Any] | None = None
+    workspace_snapshot: dict[str, Any] | None = None
 
 
 class LongformUatExecutionError(RuntimeError):
@@ -342,6 +344,29 @@ def render_failure_markdown_report(report: LongformUatFailureReport) -> str:
     story_title = report.story_title or "n/a"
     principal_workspace_id = report.principal_workspace_id or "n/a"
     workspace_id = report.workspace_id or "n/a"
+    job_payload = report.job_payload or {}
+    job_status = str(job_payload.get("status", "n/a"))
+    job_operation = str(job_payload.get("operation", "n/a"))
+    job_provider = str(job_payload.get("provider", "n/a"))
+    job_error = str(job_payload.get("error", "n/a"))
+    failure_artifact = job_payload.get("failure_artifact")
+    failure_artifact_path = "n/a"
+    if isinstance(failure_artifact, dict):
+        failure_artifact_path = str(
+            failure_artifact.get("relative_path")
+            or failure_artifact.get("filename")
+            or failure_artifact.get("artifact_id")
+            or "n/a"
+        )
+    event_rows = _render_failure_event_rows(job_payload)
+    snapshot = report.workspace_snapshot or {}
+    chapters = snapshot.get("chapters", [])
+    runs = snapshot.get("runs", [])
+    jobs = snapshot.get("jobs", [])
+    drafted_count = len(chapters) if isinstance(chapters, list) else 0
+    run_count = len(runs) if isinstance(runs, list) else 0
+    job_count = len(jobs) if isinstance(jobs, list) else 0
+    run_event_rows = _render_workspace_run_event_rows(snapshot)
 
     return f"""# DashScope 20-Chapter Live Evidence
 
@@ -358,12 +383,80 @@ def render_failure_markdown_report(report: LongformUatFailureReport) -> str:
 - failed step: `{report.failed_step}`
 - error: `{report.error_message}`
 
+## Failed Job
+
+- status: `{job_status}`
+- operation: `{job_operation}`
+- provider: `{job_provider}`
+- job error: `{job_error}`
+- failure artifact: `{failure_artifact_path}`
+
+| Event status | Details |
+| --- | --- |
+{event_rows}
+
+## Workspace Snapshot
+
+- drafted chapters observed: `{drafted_count}`
+- run count: `{run_count}`
+- job count: `{job_count}`
+
+| Run event status | Details |
+| --- | --- |
+{run_event_rows}
+
 ## Request Trace
 
 | Step | Request | Status | Duration (ms) |
 | --- | --- | --- | --- |
 {request_rows}
 """
+
+
+def _short_json(value: object, *, limit: int = 240) -> str:
+    text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    text = text.replace("\n", " ").replace("|", "\\|")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def _render_failure_event_rows(job_payload: dict[str, Any]) -> str:
+    events = job_payload.get("events", [])
+    if not isinstance(events, list) or not events:
+        return "| none | n/a |"
+    rows: list[str] = []
+    for event in events[-6:]:
+        if not isinstance(event, dict):
+            continue
+        rows.append(
+            "| "
+            f"{str(event.get('status', 'n/a'))} | "
+            f"{_short_json(event.get('details', {}))} |"
+        )
+    return "\n".join(rows) or "| none | n/a |"
+
+
+def _render_workspace_run_event_rows(snapshot: dict[str, Any]) -> str:
+    runs = snapshot.get("runs", [])
+    if not isinstance(runs, list) or not runs:
+        return "| none | n/a |"
+    latest_run = runs[0]
+    if not isinstance(latest_run, dict):
+        return "| none | n/a |"
+    events = latest_run.get("events", [])
+    if not isinstance(events, list) or not events:
+        return "| none | n/a |"
+    rows: list[str] = []
+    for event in events[-8:]:
+        if not isinstance(event, dict):
+            continue
+        rows.append(
+            "| "
+            f"{str(event.get('status', 'n/a'))} | "
+            f"{_short_json(event.get('details', {}))} |"
+        )
+    return "\n".join(rows) or "| none | n/a |"
 
 
 def _request_json(
@@ -580,6 +673,29 @@ def _poll_job_until_terminal(
     raise RuntimeError(f"{step} did not finish within {timeout_seconds} seconds: {payload}")
 
 
+def _try_fetch_workspace_snapshot(
+    session: requests.Session,
+    traces: list[RequestTrace],
+    *,
+    base_url: str,
+    workspace_id: str,
+    timeout_seconds: int,
+) -> dict[str, Any] | None:
+    try:
+        _, payload = _request_json(
+            session,
+            traces,
+            base_url=base_url,
+            step="get_workspace_after_failed_job",
+            method="GET",
+            path=f"/api/workspaces/{workspace_id}",
+            timeout_seconds=timeout_seconds,
+        )
+    except (RuntimeError, requests.RequestException):
+        return None
+    return payload
+
+
 def _resolve_output_paths(
     *,
     output_dir: Path,
@@ -610,6 +726,9 @@ def run_longform_uat(
     principal_workspace_id: str | None = None
     workspace_id: str | None = None
     title: str | None = None
+    latest_job_payload: dict[str, Any] | None = None
+    workspace_snapshot: dict[str, Any] | None = None
+    failed_step_override: str | None = None
 
     try:
         login_status, login_payload = _request_json(
@@ -676,7 +795,16 @@ def run_longform_uat(
             path=f"/api/workspaces/{workspace_id}/jobs/{run_job_id}",
             timeout_seconds=timeout_seconds,
         )
+        latest_job_payload = run_job_payload
         if run_job_payload.get("status") != "completed":
+            failed_step_override = "poll_run_job"
+            workspace_snapshot = _try_fetch_workspace_snapshot(
+                session,
+                traces,
+                base_url=base_url,
+                workspace_id=workspace_id,
+                timeout_seconds=timeout_seconds,
+            )
             raise RuntimeError(f"Run job failed: {run_job_payload.get('error')}")
 
         _, workspace_payload = _request_json(
@@ -688,6 +816,7 @@ def run_longform_uat(
             path=f"/api/workspaces/{workspace_id}",
             timeout_seconds=timeout_seconds,
         )
+        workspace_snapshot = workspace_payload
         final_review = dict(workspace_payload.get("latest_review") or {})
         review_rounds = 1 if final_review else 0
 
@@ -711,6 +840,7 @@ def run_longform_uat(
             path=f"/api/workspaces/{workspace_id}/jobs/{export_job_id}",
             timeout_seconds=timeout_seconds,
         )
+        latest_job_payload = export_job_payload
         _, workspace_payload = _request_json(
             session,
             traces,
@@ -720,6 +850,7 @@ def run_longform_uat(
             path=f"/api/workspaces/{workspace_id}",
             timeout_seconds=timeout_seconds,
         )
+        workspace_snapshot = workspace_payload
 
         final_review = dict(workspace_payload.get("latest_review") or final_review)
         warning_count, blocker_count, suggestion_count = _issue_counts(final_review)
@@ -807,7 +938,7 @@ def run_longform_uat(
         validate_report(report)
         return report
     except (RuntimeError, ValueError, requests.RequestException) as exc:
-        failed_step = traces[-1].step if traces else "startup"
+        failed_step = failed_step_override or (traces[-1].step if traces else "startup")
         raise LongformUatExecutionError(
             LongformUatFailureReport(
                 started_at=started_at,
@@ -821,6 +952,8 @@ def run_longform_uat(
                 failed_step=failed_step,
                 error_message=str(exc),
                 request_trace=traces,
+                job_payload=latest_job_payload,
+                workspace_snapshot=workspace_snapshot,
             )
         ) from exc
 

--- a/src/contexts/narrative/application/services/local_writing_engine.py
+++ b/src/contexts/narrative/application/services/local_writing_engine.py
@@ -6,6 +6,7 @@ sidecar evidence for planning, review, and recovery.
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import json
 import os
@@ -24,6 +25,7 @@ import yaml
 
 from src.contexts.ai.application.ports.text_generation_port import (
     TextGenerationProvider,
+    TextGenerationProviderError,
     TextGenerationResult,
     TextGenerationTask,
 )
@@ -33,6 +35,8 @@ ReviewSeverity = Literal["blocker", "warning", "suggestion"]
 LOCK_STALE_AFTER_SECONDS = 60 * 60
 LOCK_WAIT_SECONDS = 30.0
 LOCK_POLL_SECONDS = 0.05
+CHAPTER_GENERATION_ATTEMPTS = 2
+CHAPTER_GENERATION_RETRY_DELAY_SECONDS = 0.25
 
 FORBIDDEN_TEMPLATE_PHRASES = (
     "Revision anchor:",
@@ -624,38 +628,51 @@ class LocalDraftingEngine:
 
         config = workspace.load_config()
         task = self._build_task(workspace, config, chapter_number)
-        try:
-            result = await self._provider.generate_structured(
-                self._generation_task(task)
-            )
-            artifact = self._extract_artifact(
-                result,
-                chapter_number=chapter_number,
-                run_id=current_run_dir.name,
-            )
-            self._validate_chapter_surface(artifact.chapter_markdown)
-            workspace.write_chapter(chapter_number, artifact.chapter_markdown)
-            workspace.store_artifact(artifact, current_run_dir)
-            workspace.append_event(
-                current_run_dir,
-                "draft",
-                "completed",
-                {
-                    "chapter_number": chapter_number,
-                    "chapter_relative_path": workspace.relative_path(
-                        workspace.chapter_path(chapter_number)
-                    ),
-                },
-            )
-            return artifact
-        except Exception as exc:
-            workspace.append_event(
-                current_run_dir,
-                "draft",
-                "failed",
-                {"chapter_number": chapter_number, "error": str(exc)},
-            )
-            raise
+        generation_task = self._generation_task(task)
+        for attempt in range(1, CHAPTER_GENERATION_ATTEMPTS + 1):
+            try:
+                result = await self._provider.generate_structured(generation_task)
+                artifact = self._extract_artifact(
+                    result,
+                    chapter_number=chapter_number,
+                    run_id=current_run_dir.name,
+                )
+                self._validate_chapter_surface(artifact.chapter_markdown)
+                workspace.write_chapter(chapter_number, artifact.chapter_markdown)
+                workspace.store_artifact(artifact, current_run_dir)
+                workspace.append_event(
+                    current_run_dir,
+                    "draft",
+                    "completed",
+                    {
+                        "chapter_number": chapter_number,
+                        "attempt": attempt,
+                        "chapter_relative_path": workspace.relative_path(
+                            workspace.chapter_path(chapter_number)
+                        ),
+                    },
+                )
+                return artifact
+            except Exception as exc:
+                should_retry = (
+                    attempt < CHAPTER_GENERATION_ATTEMPTS
+                    and self._is_retryable_generation_error(exc)
+                )
+                workspace.append_event(
+                    current_run_dir,
+                    "draft",
+                    "retrying" if should_retry else "failed",
+                    {
+                        "chapter_number": chapter_number,
+                        "attempt": attempt,
+                        "error": str(exc),
+                    },
+                )
+                if not should_retry:
+                    raise
+                await asyncio.sleep(CHAPTER_GENERATION_RETRY_DELAY_SECONDS)
+
+        raise RuntimeError("chapter generation exhausted without a terminal error")
 
     async def revise_chapter(
         self,
@@ -859,6 +876,16 @@ class LocalDraftingEngine:
         for phrase in FORBIDDEN_TEMPLATE_PHRASES:
             if phrase.lower() in lowered:
                 raise ValueError(f"Chapter prose contains forbidden phrase: {phrase}")
+
+    @staticmethod
+    def _is_retryable_generation_error(exc: Exception) -> bool:
+        message = str(exc).lower()
+        if isinstance(exc, TextGenerationProviderError):
+            return "not a json object" in message or "invalid json" in message
+        return (
+            "provider returned empty chapter_markdown" in message
+            or "chapter prose contains forbidden phrase" in message
+        )
 
 
 EDITORIAL_DIMENSIONS: tuple[tuple[str, str], ...] = (

--- a/tests/apps/cli/test_novel_engine.py
+++ b/tests/apps/cli/test_novel_engine.py
@@ -70,6 +70,44 @@ class MechanicalPhraseProvider:
         )
 
 
+class FlakyChapterProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate_structured(
+        self,
+        task: TextGenerationTask,
+    ) -> TextGenerationResult:
+        self.calls += 1
+        if self.calls == 1:
+            raise TextGenerationProviderError(
+                f"provider failed for {task.step}: not a JSON object"
+            )
+        payload = {
+            "chapter_markdown": (
+                "# Chapter 1: The Bell Debt\n\n"
+                "Mira followed the bell through the flooded arcade while every "
+                "shopkeeper pretended not to hear it. The sound named a debt before "
+                "the collector arrived, and that made the silence around her feel "
+                "too carefully arranged."
+            ),
+            "sidecar_metadata": {
+                "summary": "Mira follows a bell debt into the arcade.",
+                "characters": ["Mira"],
+                "promises": [],
+                "continuity_changes": [],
+                "style_notes": [],
+            },
+        }
+        return TextGenerationResult(
+            step=task.step,
+            provider="mock",
+            model="flaky-chapter-fixture",
+            raw_text=json.dumps(payload, ensure_ascii=False),
+            content=payload,
+        )
+
+
 class FailingEditorialProvider:
     async def generate_structured(
         self,
@@ -135,6 +173,31 @@ async def test_provider_mechanical_phrases_are_sanitized_before_storage(
     assert "The scene settles with Mira stepping into the counting room." in chapter_text
     assert "first draft" in artifact.raw_model_output.lower()
     assert artifact.chapter_markdown == chapter_text.strip()
+
+
+@pytest.mark.asyncio
+async def test_draft_retries_retryable_provider_errors(tmp_path: Path) -> None:
+    workspace = build_workspace(tmp_path, target_chapters=1)
+    provider = FlakyChapterProvider()
+    engine = LocalDraftingEngine(provider)
+
+    artifact = await engine.draft_chapter(workspace, 1)
+
+    assert provider.calls == 2
+    assert artifact.chapter_markdown.startswith("# Chapter 1:")
+    events_path = workspace.runs_dir / artifact.run_id / "events.jsonl"
+    events = [
+        json.loads(line)
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(
+        event["status"] == "retrying"
+        and event["details"]["chapter_number"] == 1
+        and event["details"]["attempt"] == 1
+        for event in events
+    )
+    assert events[-1]["status"] == "completed"
+    assert events[-1]["details"]["attempt"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/test_run_dashscope_longform_uat.py
+++ b/tests/scripts/test_run_dashscope_longform_uat.py
@@ -196,6 +196,67 @@ def test_render_failure_markdown_report_includes_error_and_trace() -> None:
     assert "Workspace job failed." in markdown
 
 
+def test_render_failure_markdown_report_includes_job_context() -> None:
+    report = LongformUatFailureReport(
+        started_at="2026-01-01T00:00:00+00:00",
+        completed_at="2026-01-01T00:02:00+00:00",
+        base_url="http://127.0.0.1:8000",
+        target_chapters=20,
+        story_title_seed="DashScope PR Gate",
+        principal_workspace_id="user-operator",
+        workspace_id="story-1",
+        story_title="Story",
+        failed_step="poll_run_job",
+        error_message="Run job failed: provider returned malformed output.",
+        request_trace=[],
+        job_payload={
+            "status": "failed",
+            "operation": "run",
+            "provider": "dashscope",
+            "error": "provider returned malformed output",
+            "failure_artifact": {
+                "relative_path": "artifacts/jobs/job-1.failure.json"
+            },
+            "events": [
+                {"status": "running", "details": {}},
+                {
+                    "status": "failed",
+                    "details": {
+                        "failure_artifact": {
+                            "relative_path": "artifacts/jobs/job-1.failure.json"
+                        }
+                    },
+                },
+            ],
+        },
+        workspace_snapshot={
+            "chapters": [{"chapter_number": 1}],
+            "runs": [
+                {
+                    "events": [
+                        {
+                            "status": "retrying",
+                            "details": {
+                                "chapter_number": 2,
+                                "attempt": 1,
+                                "error": "not a JSON object",
+                            },
+                        }
+                    ]
+                }
+            ],
+            "jobs": [{"job_id": "job-1"}],
+        },
+    )
+
+    markdown = render_failure_markdown_report(report)
+
+    assert "Failed Job" in markdown
+    assert "artifacts/jobs/job-1.failure.json" in markdown
+    assert "drafted chapters observed: `1`" in markdown
+    assert "chapter_number" in markdown
+
+
 def test_validate_report_allows_unresolved_warnings() -> None:
     report = _uat_report(
         warning_count=1,
@@ -423,3 +484,102 @@ def test_run_longform_uat_wraps_failures_with_partial_context(
     assert report.story_title.startswith("DashScope PR Gate")
     assert report.failed_step == "create_workspace"
     assert report.error_message == "provider timeout"
+
+
+def test_run_longform_uat_captures_failed_job_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_request_json(
+        session: Any,
+        traces: list[RequestTrace],
+        *,
+        base_url: str,
+        step: str,
+        method: str,
+        path: str,
+        headers: dict[str, str] | None = None,
+        payload: dict[str, Any] | None = None,
+        allowed_status_codes: tuple[int, ...] = (200,),
+        timeout_seconds: int = 900,
+    ) -> tuple[int, dict[str, Any]]:
+        del session, base_url, headers, allowed_status_codes, timeout_seconds
+        status_code = 201 if step == "create_workspace" else 202 if method == "POST" else 200
+        traces.append(
+            RequestTrace(
+                step=step,
+                method=method,
+                path=path,
+                status_code=status_code,
+                duration_ms=25,
+            )
+        )
+        if step == "login":
+            return 200, {"workspace_id": "user-operator"}
+        if step == "create_workspace":
+            assert payload is not None
+            return 201, {"workspace_id": str(payload["workspace_id"])}
+        if step == "run_workspace":
+            return 202, {"job_id": "run-job", "status": "queued"}
+        if step == "poll_run_job":
+            return 200, {
+                "job_id": "run-job",
+                "status": "failed",
+                "operation": "run",
+                "provider": "dashscope",
+                "error": "DashScope response is not a JSON object",
+                "failure_artifact": {
+                    "relative_path": "artifacts/jobs/run-job.failure.json"
+                },
+                "events": [
+                    {"status": "running", "details": {}},
+                    {
+                        "status": "failed",
+                        "details": {
+                            "failure_artifact": {
+                                "relative_path": "artifacts/jobs/run-job.failure.json"
+                            }
+                        },
+                    },
+                ],
+            }
+        if step == "get_workspace_after_failed_job":
+            return 200, {
+                "chapters": [{"chapter_number": 1}],
+                "runs": [
+                    {
+                        "run_id": "run-1",
+                        "events": [
+                            {
+                                "status": "retrying",
+                                "details": {
+                                    "chapter_number": 2,
+                                    "attempt": 1,
+                                    "error": "not a JSON object",
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "jobs": [{"job_id": "run-job"}],
+            }
+        raise AssertionError(f"Unexpected step: {step}")
+
+    monkeypatch.setattr(longform_uat, "_request_json", fake_request_json)
+
+    with pytest.raises(LongformUatExecutionError) as exc_info:
+        longform_uat.run_longform_uat(
+            base_url="http://127.0.0.1:8000",
+            target_chapters=20,
+            story_title_seed="DashScope PR Gate",
+            timeout_seconds=10,
+        )
+
+    report = exc_info.value.report
+    assert report.failed_step == "poll_run_job"
+    assert report.error_message == "Run job failed: DashScope response is not a JSON object"
+    assert report.job_payload is not None
+    assert report.job_payload["failure_artifact"]["relative_path"].endswith(
+        "run-job.failure.json"
+    )
+    assert report.workspace_snapshot is not None
+    assert report.workspace_snapshot["runs"][0]["events"][0]["details"]["attempt"] == 1


### PR DESCRIPTION
## Summary
- add a bounded retry loop around chapter drafting for retryable provider-shape failures
- record retry attempt events in run artifacts
- enrich failed longform UAT evidence with terminal job payload and workspace snapshot context

## Test Plan
- uv run pytest -q tests/apps/cli/test_novel_engine.py tests/contexts/ai/infrastructure/test_text_generation_providers.py tests/scripts/test_run_dashscope_longform_uat.py
- uv run pytest -q tests/apps/api/test_workspaces.py tests/apps/cli/test_novel_engine.py tests/scripts/test_run_dashscope_longform_uat.py
- uv run ruff check src/contexts/narrative/application/services/local_writing_engine.py scripts/uat/run_dashscope_longform_uat.py tests/apps/cli/test_novel_engine.py tests/scripts/test_run_dashscope_longform_uat.py
- uv lock --check
- npm --prefix frontend run type-check
- npm --prefix frontend run audit:exports
- pre-push hook full gate