### PR TITLE
docs: refresh DashScope live UAT evidence

### DIFF
--- a/docs/reports/uat/LONGFORM_DASHSCOPE_LIVE_EVIDENCE.json
+++ b/docs/reports/uat/LONGFORM_DASHSCOPE_LIVE_EVIDENCE.json
@@ -1,14 +1,1078 @@
 {
-  "status": "pending_live_refresh",
-  "reason": "The previous canonical live evidence targeted the removed story workflow. Run the DashScope longform UAT script to replace this placeholder with fresh workspace/job evidence.",
-  "refresh_command": "uv run python scripts/uat/run_dashscope_longform_uat.py --target-chapters 20 --write-canonical-reports",
-  "expected_contract": {
-    "workspace_create_path": "/api/workspaces",
-    "workspace_status_path": "/api/workspaces/{workspace_id}",
-    "workspace_jobs_path": "/api/workspaces/{workspace_id}/jobs",
-    "target_chapters_minimum": 20,
-    "required_export_outcome": "exported",
-    "allowed_warning_behavior": "warnings are editorial advice and do not block export",
-    "required_blocker_count": 0
-  }
+  "started_at": "2026-06-08T02:39:16.474197+00:00",
+  "completed_at": "2026-06-08T02:45:05.518238+00:00",
+  "base_url": "http://127.0.0.1:44811",
+  "principal_workspace_id": "user-b49a61a6-423b-4caa-bc39-6828c09cffaf",
+  "workspace_id": "dashscope-release-uat-2026-06-08-20260608-023917",
+  "story_title": "DashScope Release UAT 2026-06-08 20260608-023917",
+  "provider": "dashscope",
+  "model": "qwen3.5-flash",
+  "review_provider": "local",
+  "review_model": "local-reviewer",
+  "target_chapters": 20,
+  "drafted_chapters": 20,
+  "exported": true,
+  "export_outcome": "exported",
+  "export_failure_code": null,
+  "export_path": "exports/manuscript.md",
+  "warning_count": 0,
+  "blocker_count": 0,
+  "suggestion_count": 6,
+  "review_rounds": 1,
+  "export_gate_passed": true,
+  "issue_codes": [
+    "agency_attribution",
+    "causal_continuity",
+    "reader_pull",
+    "closure_spacing",
+    "promise_trust",
+    "voice_stability"
+  ],
+  "run_ids": [
+    "2026-06-08T023917-017733Z-58ed354e"
+  ],
+  "artifact_kinds": [
+    "chapter_artifacts",
+    "review",
+    "export"
+  ],
+  "editorial_notes": [
+    "Markdown chapters are the manuscript authority."
+  ],
+  "request_trace": [
+    {
+      "step": "login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "status_code": 200,
+      "duration_ms": 529
+    },
+    {
+      "step": "create_workspace",
+      "method": "POST",
+      "path": "/api/workspaces",
+      "status_code": 201,
+      "duration_ms": 7
+    },
+    {
+      "step": "run_workspace",
+      "method": "POST",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs",
+      "status_code": 202,
+      "duration_ms": 5
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 5
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 5
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 4
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_run_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9",
+      "status_code": 200,
+      "duration_ms": 7
+    },
+    {
+      "step": "get_workspace_after_run",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917",
+      "status_code": 200,
+      "duration_ms": 20
+    },
+    {
+      "step": "export_workspace",
+      "method": "POST",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs",
+      "status_code": 202,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_export_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/b2f9fb17-cf8d-4981-832a-3025ab35d716",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "poll_export_job",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/b2f9fb17-cf8d-4981-832a-3025ab35d716",
+      "status_code": 200,
+      "duration_ms": 3
+    },
+    {
+      "step": "get_workspace_after_export",
+      "method": "GET",
+      "path": "/api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917",
+      "status_code": 200,
+      "duration_ms": 18
+    }
+  ],
+  "chapter_audit": [
+    {
+      "chapter_number": 1,
+      "title": "chapter-001.md",
+      "word_count": 884,
+      "summary": "Senior Archivist Elara discovers that erasing oaths creates living ghosts of the forgotten promises. After accidentally crossing out a Duke's vow to lower grain taxes, she is confronted by a manifestation of that erased oath, who warns that continued erasure will cause the city's rulers and history to vanish entirely. Elara resolves to rewrite the lost memory to save the city."
+    },
+    {
+      "chapter_number": 2,
+      "title": "chapter-002.md",
+      "word_count": 1089,
+      "summary": "Elara confronts the living ghost of an erased oath, which reveals that continued erasure causes the city's rulers and history to vanish. To save Oakhaven, she rewrites the memory of the Duke's tax vow, absorbing the collective grief of the forgotten populace. Though the immediate threat is halted, she realizes the High Council's systematic erasure continues, setting her on a path to recover the city's entire lost history."
+    },
+    {
+      "chapter_number": 3,
+      "title": "chapter-003.md",
+      "word_count": 951,
+      "summary": "Elara confronts a manifestation of erased oaths who reveals the High Council is systematically erasing their own history to prevent accountability. Realizing that unchecked erasure will cause the rulers and the city's legal foundation to vanish entirely, Elara accepts her role as the 'Archivist of the Lost' and prepares to wage war against the Council using the restored memories found in the ash."
+    },
+    {
+      "chapter_number": 4,
+      "title": "chapter-004.md",
+      "word_count": 1034,
+      "summary": "Elara confronts a fragmented ghost of erased debts in the lower vault, realizing the Council's systematic erasure threatens the city's physical existence. She begins writing in the 'Ledger of Return,' physically manifesting forgotten memories to counteract the erasure. The process transforms the ghost into a living person, proving that memory can restore reality. Elara resolves to move upstairs to challenge the High Council directly, asserting that memory is the ultimate authority."
+    },
+    {
+      "chapter_number": 5,
+      "title": "chapter-005.md",
+      "word_count": 1099,
+      "summary": "Elara ascends to the Upper Spires to confront the High Council directly. Using the 'Ledger of Return', she forces the Council to confront the erased history they sought to hide. By reading the forgotten oaths aloud, she breaks their erasure magic, causing the Council members to physically manifest and remember their crimes. The chapter ends with the city of Oakhaven stabilized by the return of its true history, though Elara acknowledges the larger conflict ahead."
+    },
+    {
+      "chapter_number": 6,
+      "title": "chapter-006.md",
+      "word_count": 890,
+      "summary": "Elara forces the restored High Council to confront their erased crimes by reading the Ledger of Return, stabilizing the city's physical existence. The Council begins writing their confessions, marking the start of a public reckoning, though Elara recognizes the larger conflict ahead."
+    },
+    {
+      "chapter_number": 7,
+      "title": "chapter-007.md",
+      "word_count": 782,
+      "summary": "Following the forced confessions of the High Council regarding their erased debts and crimes, Elara realizes that while the immediate crisis is resolved, the source of the erasure magic remains unknown. The Council begins the process of public accountability, but Elara identifies the need to hunt down the architect behind the systematic erasure, setting the stage for a larger conflict involving blood and fire."
+    },
+    {
+      "chapter_number": 8,
+      "title": "chapter-008.md",
+      "word_count": 1445,
+      "summary": "Elara confronts the true architect of the erasure magic, revealed to be a spectral entity linked to Duke Kaelen Vane's legacy. Realizing that the source of the void is a living absence, she uses a symbolic object—the ancient leaf—to anchor the truth in reality, forcing the entity into the Ledger. The immediate threat is neutralized, but Elara recognizes the existence of other architects, setting the stage for a wider war to reclaim the city's complete history."
+    },
+    {
+      "chapter_number": 9,
+      "title": "chapter-009.md",
+      "word_count": 769,
+      "summary": "Elara realizes that neutralizing Duke Kaelen Vane's spectral form was only a temporary victory; the systematic erasure is part of a larger network of 'architects.' With the High Council restored and confessing, Elara directs their attention to the 'Silent Quarter,' a hidden sector where the true blueprints of the erasure likely reside, setting the stage for a deeper investigation into the machinery of forgetting."
+    },
+    {
+      "chapter_number": 10,
+      "title": "chapter-010.md",
+      "word_count": 1313,
+      "summary": "Elara, Thorne, and Vane investigate the Silent Quarter, discovering that the erasure magic is part of an industrial-scale 'audit' system designed to liquidate memories as financial assets. They confront a porcelain-masked entity representing the 'banker' of forgetting. Elara uses the ancient leaf to anchor the truth, shattering the entity's power and forcing the erasure machinery to collapse. While the immediate threat is neutralized, Elara realizes this was merely a branch operation, and the true owners of the 'ledger' remain at large, setting the stage for a hunt for the source of the global erasure network."
+    },
+    {
+      "chapter_number": 11,
+      "title": "chapter-011.md",
+      "word_count": 1180,
+      "summary": "Elara, Thorne, and Vane escape the Silent Quarter after defeating the porcelain-masked banker. Elara discovers a 'balance sheet' symbol that reveals the location of the global headquarters, the Apex Spire. Realizing the branch defeat was only a symptom of a larger systemic debt, Elara uses an ancient receipt to activate a portal to the head office, preparing to confront the true owners of the erasure network directly."
+    },
+    {
+      "chapter_number": 12,
+      "title": "chapter-012.md",
+      "word_count": 1238,
+      "summary": "Elara, Thorne, and Vane arrive at the Apex Spire, the global headquarters of the erasure network. Confronting the faceless Architect, Elara uses the ancient leaf to anchor the truth, shattering the system's control and forcing the return of erased memories. The chapter ends with the Spire collapsing under the weight of recovered history, marking a turning point from destruction to restoration."
+    },
+    {
+      "chapter_number": 13,
+      "title": "chapter-013.md",
+      "word_count": 1392,
+      "summary": "After the collapse of the Apex Spire and the return of erased memories, the team confronts the Auditor General, a higher-level entity who reveals that restoring memories creates a massive 'debt' of trauma and obligation. The Auditor threatens to trigger a default, overwhelming the city with the weight of its past. Elara counters by using a mysterious blank receipt to forge a new contract based on the power of promises rather than financial debt, setting up a direct confrontation with the true owners of the global ledger."
+    },
+    {
+      "chapter_number": 14,
+      "title": "chapter-014.md",
+      "word_count": 1011,
+      "summary": "Elara confronts the Auditor General in the collapsing Apex Spire. As the entity threatens to trigger a 'default' that would overwhelm the city with traumatic memories, Elara uses a blank receipt to forge a new contract based on mutual acknowledgment and promises rather than financial debt. The spell shatters the Auditor's power, dissolving him into the memories he hoarded and restoring the city's citizens. The team accepts the burden of their history, marking the transition from systemic erasure to voluntary remembrance."
+    },
+    {
+      "chapter_number": 15,
+      "title": "chapter-015.md",
+      "word_count": 718,
+      "summary": "Following the dissolution of the Auditor General, Elara, Thorne, and Vane witness the city of Oakhaven waking from its enforced amnesia. Elara explains that while the financial debt has been transformed into a voluntary acknowledgment of history, the threat of other Auditors remains. The trio decides to shift from destruction to reconstruction, committing to teaching the citizens to reclaim their memories and rewrite their own social contracts. The chapter ends with the group standing together as the sun rises over a restored, albeit scarred, city."
+    },
+    {
+      "chapter_number": 16,
+      "title": "chapter-016.md",
+      "word_count": 742,
+      "summary": "Chapter 16: The Ledger of Living Things The sun over Oakhaven did not rise so much as it bled through the cracks in the sky, painting the cobblestones in hues of bruised purple and honest gold. For three days, the city had held its breath,"
+    },
+    {
+      "chapter_number": 17,
+      "title": "chapter-017.md",
+      "word_count": 737,
+      "summary": "Oakhaven begins the difficult process of integrating its restored memories. Elara, Thorne, and Vane realize that while the financial debt has been transformed into voluntary acknowledgment, the emotional burden is overwhelming. They commit to a new mission: teaching the citizens to manage their history and rewrite social contracts, preparing for future threats from other Auditors."
+    },
+    {
+      "chapter_number": 18,
+      "title": "chapter-018.md",
+      "word_count": 875,
+      "summary": "Oakhaven begins the painful process of integrating restored memories. Elara leads the citizens in a public demonstration of 'negotiating' their debts rather than being crushed by them, transforming trauma into voluntary obligations. While the immediate crisis of amnesia is resolved, Thorne and Vane recognize that the broader system of Auditors remains a threat, setting the stage for a war of ideology where the city must prove that voluntary remembrance can withstand systemic erasure."
+    },
+    {
+      "chapter_number": 19,
+      "title": "chapter-019.md",
+      "word_count": 951,
+      "summary": "Oakhaven begins the painful process of integrating restored memories. Elara leads the citizens in a public demonstration of 'negotiating' their debts rather than being crushed by them, transforming trauma into voluntary obligations. While the immediate crisis of amnesia is resolved, Thorne and Vane recognize that the broader system of Auditors remains a threat, setting the stage for a war of ideology where the city must prove that voluntary remembrance can withstand systemic erasure."
+    },
+    {
+      "chapter_number": 20,
+      "title": "chapter-020.md",
+      "word_count": 793,
+      "summary": "In the aftermath of the Auditor General's defeat, Oakhaven faces a new threat as spectral entities from the North District begin to materialize, signaling the arrival of other Auditors. Elara, Thorne, and Vane realize that the city's survival depends not on fighting with weapons, but on reinforcing the collective memory of its citizens. They rally the populace to actively reclaim and vocalize their histories, transforming the city's trauma into an unassailable fortress of truth just as the hostile ghosts arrive."
+    }
+  ],
+  "editorial_findings": [
+    {
+      "severity": "info",
+      "area": "workspace review",
+      "chapter": 19,
+      "summary": "Passive voice dominates descriptions of the city's restoration.",
+      "recommendation": "Shift the agency of the city's healing from abstract forces (e.g., 'the city breathed,' 'the city woke') back to the characters and the citizens. Show Elara, Thorne, Vane, and the populace actively *doing* the work of remembrance (speaking names, writing ledgers, sharing stories) rather than having the city simply 'recover' on its own. This reinforces the theme of voluntary action over passive fate."
+    },
+    {
+      "severity": "info",
+      "area": "workspace review",
+      "chapter": 20,
+      "summary": "Inconsistent timeline regarding the 'three days' of city suspension.",
+      "recommendation": "Clarify the timeline of the 'three days' mentioned in the later chapters. It appears abruptly in Chapter 16 without prior context for when this period began relative to the Auditor General's defeat in Chapter 14/15. Ensure the transition from the immediate aftermath of the battle to this three-day recovery period is explicitly bridged to avoid confusion about the story's chronology."
+    },
+    {
+      "severity": "info",
+      "area": "workspace review",
+      "chapter": 20,
+      "summary": "Chapter titles lack distinctiveness and thematic progression.",
+      "recommendation": "Differentiate chapter titles to better reflect the shifting stakes and plot points. Currently, many titles follow a similar 'The [Noun] of [Abstract Concept]' structure (e.g., 'The Ink That Bleeds', 'The Ashen Ledger', 'The Weight of Ink'). Consider using more active or character-driven titles that hint at the specific conflict or revelation within each chapter to increase reader curiosity."
+    },
+    {
+      "severity": "info",
+      "area": "workspace review",
+      "chapter": null,
+      "summary": "Recent endings show this cadence: \"chapter-018: first time in generations, the people of Oakhaven were holding the pen. / chapter-019: ot written in sto...\".",
+      "recommendation": "Vary whether chapters end on release, reversal, or delayed consequence."
+    },
+    {
+      "severity": "info",
+      "area": "workspace review",
+      "chapter": 19,
+      "summary": "Overuse of the 'blank receipt' artifact reduces its narrative weight.",
+      "recommendation": "Reserve the 'blank receipt' for critical turning points rather than using it as a recurring tool for general problem-solving. If Elara uses it to forge contracts or teach citizens multiple times, consider introducing limitations, costs, or alternative methods to prevent the solution from feeling too easy or devaluing the artifact's initial introduction."
+    },
+    {
+      "severity": "info",
+      "area": "workspace review",
+      "chapter": null,
+      "summary": "Repetitive use of 'silence' as a primary atmospheric descriptor creates monotony.",
+      "recommendation": "Vary the sensory vocabulary used to describe the atmosphere. Instead of repeatedly describing silence as 'heavy,' 'pressurized,' or 'empty,' try focusing on other senses: the taste of ozone, the texture of dust, the specific pitch of bells, or the visual distortion of light. This will maintain tension without making the prose feel repetitive."
+    }
+  ]
 }

--- a/docs/reports/uat/LONGFORM_DASHSCOPE_LIVE_EVIDENCE.md
+++ b/docs/reports/uat/LONGFORM_DASHSCOPE_LIVE_EVIDENCE.md
@@ -1,27 +1,200 @@
 # DashScope 20-Chapter Live Evidence
 
-## Refresh Required
+## Summary
 
-The previous checked-in evidence was captured against the removed story
-workflow. It has been cleared from the active UAT baseline so it cannot be
-mistaken for proof of the current local workspace path.
+- started: `2026-06-08T02:39:16.474197+00:00`
+- completed: `2026-06-08T02:45:05.518238+00:00`
+- base URL: `http://127.0.0.1:44811`
+- story: `DashScope Release UAT 2026-06-08 20260608-023917`
+- principal workspace: `user-b49a61a6-423b-4caa-bc39-6828c09cffaf`
+- workspace: `dashscope-release-uat-2026-06-08-20260608-023917`
+- provider/model: `dashscope` / `qwen3.5-flash`
+- review provider/model: `local` / `local-reviewer`
+- target chapters: `20`
+- drafted chapters: `20`
+- export outcome: `exported`
+- export failure code: `n/a`
+- export path: `exports/manuscript.md`
+- review rounds: `1`
 
-Refresh this file with a live DashScope run when a human-reviewed baseline is
-needed:
+## Machine Evidence
 
-```bash
-uv run python scripts/uat/run_dashscope_longform_uat.py --target-chapters 20 --write-canonical-reports
-```
+- warnings: `0`
+- blockers: `0`
+- suggestions: `6`
+- export gate: `pass`
+- exported: `yes`
+- issue codes: `agency_attribution, causal_continuity, reader_pull, closure_spacing, promise_trust, voice_stability`
+- run IDs: `2026-06-08T023917-017733Z-58ed354e`
+- artifact kinds: `chapter_artifacts, review, export`
 
-The refreshed report must show:
+## Editorial Review
 
-- `POST /api/workspaces`
-- `POST /api/workspaces/{workspace_id}/jobs` with `operation=run`
-- `GET /api/workspaces/{workspace_id}`
-- `POST /api/workspaces/{workspace_id}/jobs` with `operation=export`
-- drafted chapters `>= 20`
-- export outcome `exported`
-- blocker count `0`
+Workspace review was generated from local chapter Markdown and sidecar metadata. Warnings are editorial advice; only blockers prevent export.
 
-Warnings are expected to remain visible as editorial advice and do not block
-export.
+| Severity | Area | Chapter | Finding | Recommendation |
+| --- | --- | --- | --- | --- |
+| info | workspace review | 19 | Passive voice dominates descriptions of the city's restoration. | Shift the agency of the city's healing from abstract forces (e.g., 'the city breathed,' 'the city woke') back to the characters and the citizens. Show Elara, Thorne, Vane, and the populace actively *doing* the work of remembrance (speaking names, writing ledgers, sharing stories) rather than having the city simply 'recover' on its own. This reinforces the theme of voluntary action over passive fate. |
+| info | workspace review | 20 | Inconsistent timeline regarding the 'three days' of city suspension. | Clarify the timeline of the 'three days' mentioned in the later chapters. It appears abruptly in Chapter 16 without prior context for when this period began relative to the Auditor General's defeat in Chapter 14/15. Ensure the transition from the immediate aftermath of the battle to this three-day recovery period is explicitly bridged to avoid confusion about the story's chronology. |
+| info | workspace review | 20 | Chapter titles lack distinctiveness and thematic progression. | Differentiate chapter titles to better reflect the shifting stakes and plot points. Currently, many titles follow a similar 'The [Noun] of [Abstract Concept]' structure (e.g., 'The Ink That Bleeds', 'The Ashen Ledger', 'The Weight of Ink'). Consider using more active or character-driven titles that hint at the specific conflict or revelation within each chapter to increase reader curiosity. |
+| info | workspace review | - | Recent endings show this cadence: "chapter-018: first time in generations, the people of Oakhaven were holding the pen. / chapter-019: ot written in sto...". | Vary whether chapters end on release, reversal, or delayed consequence. |
+| info | workspace review | 19 | Overuse of the 'blank receipt' artifact reduces its narrative weight. | Reserve the 'blank receipt' for critical turning points rather than using it as a recurring tool for general problem-solving. If Elara uses it to forge contracts or teach citizens multiple times, consider introducing limitations, costs, or alternative methods to prevent the solution from feeling too easy or devaluing the artifact's initial introduction. |
+| info | workspace review | - | Repetitive use of 'silence' as a primary atmospheric descriptor creates monotony. | Vary the sensory vocabulary used to describe the atmosphere. Instead of repeatedly describing silence as 'heavy,' 'pressurized,' or 'empty,' try focusing on other senses: the taste of ozone, the texture of dust, the specific pitch of bells, or the visual distortion of light. This will maintain tension without making the prose feel repetitive. |
+
+## Chapter Audit
+
+| Chapter | File | Word count | Sidecar summary |
+| --- | --- | --- | --- |
+| 1 | chapter-001.md | 884 | Senior Archivist Elara discovers that erasing oaths creates living ghosts of the forgotten promises. After accidentally crossing out a Duke's vow to lower grain taxes, she is confronted by a manifestation of that erased oath, who warns that continued erasure will cause the city's rulers and history to vanish entirely. Elara resolves to rewrite the lost memory to save the city. |
+| 2 | chapter-002.md | 1089 | Elara confronts the living ghost of an erased oath, which reveals that continued erasure causes the city's rulers and history to vanish. To save Oakhaven, she rewrites the memory of the Duke's tax vow, absorbing the collective grief of the forgotten populace. Though the immediate threat is halted, she realizes the High Council's systematic erasure continues, setting her on a path to recover the city's entire lost history. |
+| 3 | chapter-003.md | 951 | Elara confronts a manifestation of erased oaths who reveals the High Council is systematically erasing their own history to prevent accountability. Realizing that unchecked erasure will cause the rulers and the city's legal foundation to vanish entirely, Elara accepts her role as the 'Archivist of the Lost' and prepares to wage war against the Council using the restored memories found in the ash. |
+| 4 | chapter-004.md | 1034 | Elara confronts a fragmented ghost of erased debts in the lower vault, realizing the Council's systematic erasure threatens the city's physical existence. She begins writing in the 'Ledger of Return,' physically manifesting forgotten memories to counteract the erasure. The process transforms the ghost into a living person, proving that memory can restore reality. Elara resolves to move upstairs to challenge the High Council directly, asserting that memory is the ultimate authority. |
+| 5 | chapter-005.md | 1099 | Elara ascends to the Upper Spires to confront the High Council directly. Using the 'Ledger of Return', she forces the Council to confront the erased history they sought to hide. By reading the forgotten oaths aloud, she breaks their erasure magic, causing the Council members to physically manifest and remember their crimes. The chapter ends with the city of Oakhaven stabilized by the return of its true history, though Elara acknowledges the larger conflict ahead. |
+| 6 | chapter-006.md | 890 | Elara forces the restored High Council to confront their erased crimes by reading the Ledger of Return, stabilizing the city's physical existence. The Council begins writing their confessions, marking the start of a public reckoning, though Elara recognizes the larger conflict ahead. |
+| 7 | chapter-007.md | 782 | Following the forced confessions of the High Council regarding their erased debts and crimes, Elara realizes that while the immediate crisis is resolved, the source of the erasure magic remains unknown. The Council begins the process of public accountability, but Elara identifies the need to hunt down the architect behind the systematic erasure, setting the stage for a larger conflict involving blood and fire. |
+| 8 | chapter-008.md | 1445 | Elara confronts the true architect of the erasure magic, revealed to be a spectral entity linked to Duke Kaelen Vane's legacy. Realizing that the source of the void is a living absence, she uses a symbolic object—the ancient leaf—to anchor the truth in reality, forcing the entity into the Ledger. The immediate threat is neutralized, but Elara recognizes the existence of other architects, setting the stage for a wider war to reclaim the city's complete history. |
+| 9 | chapter-009.md | 769 | Elara realizes that neutralizing Duke Kaelen Vane's spectral form was only a temporary victory; the systematic erasure is part of a larger network of 'architects.' With the High Council restored and confessing, Elara directs their attention to the 'Silent Quarter,' a hidden sector where the true blueprints of the erasure likely reside, setting the stage for a deeper investigation into the machinery of forgetting. |
+| 10 | chapter-010.md | 1313 | Elara, Thorne, and Vane investigate the Silent Quarter, discovering that the erasure magic is part of an industrial-scale 'audit' system designed to liquidate memories as financial assets. They confront a porcelain-masked entity representing the 'banker' of forgetting. Elara uses the ancient leaf to anchor the truth, shattering the entity's power and forcing the erasure machinery to collapse. While the immediate threat is neutralized, Elara realizes this was merely a branch operation, and the true owners of the 'ledger' remain at large, setting the stage for a hunt for the source of the global erasure network. |
+| 11 | chapter-011.md | 1180 | Elara, Thorne, and Vane escape the Silent Quarter after defeating the porcelain-masked banker. Elara discovers a 'balance sheet' symbol that reveals the location of the global headquarters, the Apex Spire. Realizing the branch defeat was only a symptom of a larger systemic debt, Elara uses an ancient receipt to activate a portal to the head office, preparing to confront the true owners of the erasure network directly. |
+| 12 | chapter-012.md | 1238 | Elara, Thorne, and Vane arrive at the Apex Spire, the global headquarters of the erasure network. Confronting the faceless Architect, Elara uses the ancient leaf to anchor the truth, shattering the system's control and forcing the return of erased memories. The chapter ends with the Spire collapsing under the weight of recovered history, marking a turning point from destruction to restoration. |
+| 13 | chapter-013.md | 1392 | After the collapse of the Apex Spire and the return of erased memories, the team confronts the Auditor General, a higher-level entity who reveals that restoring memories creates a massive 'debt' of trauma and obligation. The Auditor threatens to trigger a default, overwhelming the city with the weight of its past. Elara counters by using a mysterious blank receipt to forge a new contract based on the power of promises rather than financial debt, setting up a direct confrontation with the true owners of the global ledger. |
+| 14 | chapter-014.md | 1011 | Elara confronts the Auditor General in the collapsing Apex Spire. As the entity threatens to trigger a 'default' that would overwhelm the city with traumatic memories, Elara uses a blank receipt to forge a new contract based on mutual acknowledgment and promises rather than financial debt. The spell shatters the Auditor's power, dissolving him into the memories he hoarded and restoring the city's citizens. The team accepts the burden of their history, marking the transition from systemic erasure to voluntary remembrance. |
+| 15 | chapter-015.md | 718 | Following the dissolution of the Auditor General, Elara, Thorne, and Vane witness the city of Oakhaven waking from its enforced amnesia. Elara explains that while the financial debt has been transformed into a voluntary acknowledgment of history, the threat of other Auditors remains. The trio decides to shift from destruction to reconstruction, committing to teaching the citizens to reclaim their memories and rewrite their own social contracts. The chapter ends with the group standing together as the sun rises over a restored, albeit scarred, city. |
+| 16 | chapter-016.md | 742 | Chapter 16: The Ledger of Living Things The sun over Oakhaven did not rise so much as it bled through the cracks in the sky, painting the cobblestones in hues of bruised purple and honest gold. For three days, the city had held its breath, |
+| 17 | chapter-017.md | 737 | Oakhaven begins the difficult process of integrating its restored memories. Elara, Thorne, and Vane realize that while the financial debt has been transformed into voluntary acknowledgment, the emotional burden is overwhelming. They commit to a new mission: teaching the citizens to manage their history and rewrite social contracts, preparing for future threats from other Auditors. |
+| 18 | chapter-018.md | 875 | Oakhaven begins the painful process of integrating restored memories. Elara leads the citizens in a public demonstration of 'negotiating' their debts rather than being crushed by them, transforming trauma into voluntary obligations. While the immediate crisis of amnesia is resolved, Thorne and Vane recognize that the broader system of Auditors remains a threat, setting the stage for a war of ideology where the city must prove that voluntary remembrance can withstand systemic erasure. |
+| 19 | chapter-019.md | 951 | Oakhaven begins the painful process of integrating restored memories. Elara leads the citizens in a public demonstration of 'negotiating' their debts rather than being crushed by them, transforming trauma into voluntary obligations. While the immediate crisis of amnesia is resolved, Thorne and Vane recognize that the broader system of Auditors remains a threat, setting the stage for a war of ideology where the city must prove that voluntary remembrance can withstand systemic erasure. |
+| 20 | chapter-020.md | 793 | In the aftermath of the Auditor General's defeat, Oakhaven faces a new threat as spectral entities from the North District begin to materialize, signaling the arrival of other Auditors. Elara, Thorne, and Vane realize that the city's survival depends not on fighting with weapons, but on reinforcing the collective memory of its citizens. They rally the populace to actively reclaim and vocalize their histories, transforming the city's trauma into an unassailable fortress of truth just as the hostile ghosts arrive. |
+
+## Editorial Notes
+
+- Markdown chapters are the manuscript authority.
+
+## Request Trace
+
+| Step | Request | Status | Duration (ms) |
+| --- | --- | --- | --- |
+| login | `POST /api/auth/login` | 200 | 529 |
+| create_workspace | `POST /api/workspaces` | 201 | 7 |
+| run_workspace | `POST /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs` | 202 | 5 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 5 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 5 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 4 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 3 |
+| poll_run_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/e92346d4-fe96-4c0a-8aa3-d12b681e0dd9` | 200 | 7 |
+| get_workspace_after_run | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917` | 200 | 20 |
+| export_workspace | `POST /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs` | 202 | 3 |
+| poll_export_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/b2f9fb17-cf8d-4981-832a-3025ab35d716` | 200 | 3 |
+| poll_export_job | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917/jobs/b2f9fb17-cf8d-4981-832a-3025ab35d716` | 200 | 3 |
+| get_workspace_after_export | `GET /api/workspaces/dashscope-release-uat-2026-06-08-20260608-023917` | 200 | 18 |


### PR DESCRIPTION
## Summary
- refresh canonical DashScope 20-chapter live UAT evidence from passing workflow run 27112890876
- artifact shows 20 drafted chapters, export outcome exported, blocker count 0, and export gate pass

## Test Plan
- validated docs/reports/uat/LONGFORM_DASHSCOPE_LIVE_EVIDENCE.json acceptance fields locally
- git diff --check -- docs/reports/uat/LONGFORM_DASHSCOPE_LIVE_EVIDENCE.md docs/reports/uat/LONGFORM_DASHSCOPE_LIVE_EVIDENCE.json
- pre-push hook full gate