### PR TITLE
[codex] Fix UAT review polling and session labels

### DIFF
--- a/frontend/src/app/types/auth.ts
+++ b/frontend/src/app/types/auth.ts
@@ -37,6 +37,13 @@ export interface SessionCatalog {
   sessions: SessionState[];
 }
 
+export interface SessionSelectionUpdate {
+  lastWorkspaceId?: string | null;
+  lastJobId?: string | null;
+  lastView?: WorkspaceSurfaceView;
+  activeWorkspace?: ActiveWorkspaceSummary | null;
+}
+
 interface ActiveWorkspaceResponsePayload {
   workspace_id: string;
   workspace_kind: WorkspaceKind;

--- a/frontend/src/features/auth/AuthProvider.test.tsx
+++ b/frontend/src/features/auth/AuthProvider.test.tsx
@@ -28,6 +28,9 @@ function SessionProbe() {
       <div data-testid="session-state">{session ? session.kind : 'empty'}</div>
       <div data-testid="workspace-state">{session?.workspaceId ?? 'none'}</div>
       <div data-testid="workspace-selection">{session?.lastWorkspaceId ?? 'none'}</div>
+      <div data-testid="active-workspace-label">
+        {session?.activeWorkspace?.label ?? 'none'}
+      </div>
       <button
         data-testid="probe-sign-in"
         onClick={() =>
@@ -68,6 +71,13 @@ function SessionProbe() {
             lastWorkspaceId: 'workspace-123',
             lastJobId: 'job-456',
             lastView: 'playback',
+            activeWorkspace: {
+              workspaceId: 'workspace-123',
+              workspaceKind: 'guest',
+              label: 'The Salt Ledger',
+              persistence: 'ephemeral',
+              summary: 'workspace-123 / 2 chapters',
+            },
           })
         }
         type="button"
@@ -159,6 +169,12 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('workspace-state')).toHaveTextContent('guest-123');
     });
+    await user.click(screen.getByTestId('probe-update-selection'));
+    await waitFor(() => {
+      expect(screen.getByTestId('active-workspace-label')).toHaveTextContent(
+        'The Salt Ledger',
+      );
+    });
 
     await user.click(screen.getByTestId('probe-sign-in'));
     await waitFor(() => {
@@ -169,6 +185,9 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('workspace-state')).toHaveTextContent('guest-123');
     });
+    expect(screen.getByTestId('active-workspace-label')).toHaveTextContent(
+      'The Salt Ledger',
+    );
 
     expect(api.createGuestSession).toHaveBeenLastCalledWith({ workspace_id: 'guest-123' });
   });
@@ -188,6 +207,13 @@ describe('AuthProvider', () => {
               id: 'stale-user',
               name: 'stale',
               email: 'stale@novel.engine',
+            },
+            activeWorkspace: {
+              workspaceId: 'saved-user-story',
+              workspaceKind: 'user',
+              label: 'Saved User Story',
+              persistence: 'persistent',
+              summary: 'saved-user-story / 2 chapters',
             },
             lastWorkspaceId: null,
             lastJobId: null,
@@ -229,6 +255,9 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('session-state')).toHaveTextContent('user');
       expect(screen.getByTestId('workspace-state')).toHaveTextContent('user-123-safe');
       expect(screen.getByTestId('loading-state')).toHaveTextContent('ready');
+      expect(screen.getByTestId('active-workspace-label')).toHaveTextContent(
+        'Saved User Story',
+      );
     });
   });
 
@@ -264,6 +293,14 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('workspace-selection')).toHaveTextContent(
         'workspace-123',
       );
+    });
+    expect(screen.getByTestId('active-workspace-label')).toHaveTextContent(
+      'The Salt Ledger',
+    );
+    expect(readSessionCatalog().sessions[0].activeWorkspace).toMatchObject({
+      workspaceId: 'workspace-123',
+      label: 'The Salt Ledger',
+      summary: 'workspace-123 / 2 chapters',
     });
 
     await user.click(screen.getByTestId('probe-sign-out'));

--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -13,9 +13,9 @@ import type {
   GuestSessionResponse,
   LoginRequest,
   LoginResponse,
+  SessionSelectionUpdate,
   SessionCatalog,
   SessionState,
-  WorkspaceSurfaceView,
 } from '@/app/types/auth';
 import {
   buildSessionId,
@@ -23,7 +23,6 @@ import {
   getActiveSession,
   readSessionCatalog,
   removeSession,
-  setActiveSessionId,
   updateSessionSelection as persistSessionSelection,
   upsertSession,
 } from '@/shared/storage';
@@ -37,11 +36,7 @@ interface AuthContextValue {
   signIn: (payload: LoginRequest) => Promise<SessionState>;
   switchSession: (sessionId: string) => Promise<SessionState>;
   signOut: () => void;
-  updateSessionSelection: (selection: {
-    lastWorkspaceId?: string | null;
-    lastJobId?: string | null;
-    lastView?: WorkspaceSurfaceView;
-  }) => void;
+  updateSessionSelection: (selection: SessionSelectionUpdate) => void;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -69,23 +64,31 @@ function normalizeWorkspaceSummary(
   };
 }
 
+function preserveActiveWorkspace(
+  previous: SessionState | null | undefined,
+  fallback: ActiveWorkspaceSummary,
+): ActiveWorkspaceSummary {
+  return previous?.activeWorkspace ?? fallback;
+}
+
 function buildGuestSession(
   response: GuestSessionResponse,
   previous?: SessionState | null,
 ): SessionState {
   const workspaceId = response.workspace_id;
+  const activeWorkspace = normalizeWorkspaceSummary(response.active_workspace, {
+    workspaceId,
+    workspaceKind: response.workspace_kind ?? 'guest',
+    label: 'Guest workspace',
+    persistence: 'ephemeral',
+    summary: 'Disposable workspace for drafting and flow verification.',
+  });
   return {
     id: buildSessionId({ kind: 'guest', workspaceId }),
     kind: 'guest',
     identityKind: response.identity_kind ?? 'guest',
     workspaceId,
-    activeWorkspace: normalizeWorkspaceSummary(response.active_workspace, {
-      workspaceId,
-      workspaceKind: response.workspace_kind ?? 'guest',
-      label: 'Guest workspace',
-      persistence: 'ephemeral',
-      summary: 'Disposable workspace for drafting and flow verification.',
-    }),
+    activeWorkspace: preserveActiveWorkspace(previous, activeWorkspace),
     lastWorkspaceId: previous?.lastWorkspaceId ?? null,
     lastJobId: previous?.lastJobId ?? null,
     lastView: previous?.lastView ?? 'workspace',
@@ -99,19 +102,20 @@ function buildUserSessionFromLogin(
   previous?: SessionState | null,
 ): SessionState {
   const workspaceId = response.workspace_id;
+  const activeWorkspace = normalizeWorkspaceSummary(response.active_workspace, {
+    workspaceId,
+    workspaceKind: response.workspace_kind ?? 'user',
+    label: 'Signed-in workspace',
+    persistence: 'persistent',
+    summary: 'Stable author workspace bound to the authenticated identity.',
+  });
   return {
     id: buildSessionId({ kind: 'user', workspaceId }),
     kind: 'user',
     identityKind: response.identity_kind ?? 'user',
     workspaceId,
     user: response.user,
-    activeWorkspace: normalizeWorkspaceSummary(response.active_workspace, {
-      workspaceId,
-      workspaceKind: response.workspace_kind ?? 'user',
-      label: 'Signed-in workspace',
-      persistence: 'persistent',
-      summary: 'Stable author workspace bound to the authenticated identity.',
-    }),
+    activeWorkspace: preserveActiveWorkspace(previous, activeWorkspace),
     lastWorkspaceId: previous?.lastWorkspaceId ?? null,
     lastJobId: previous?.lastJobId ?? null,
     lastView: previous?.lastView ?? 'workspace',
@@ -125,6 +129,13 @@ function buildUserSessionFromCurrentUser(
   previous: SessionState,
 ): SessionState {
   const workspaceId = user.workspace_id;
+  const activeWorkspace = normalizeWorkspaceSummary(user.active_workspace, {
+    workspaceId,
+    workspaceKind: user.workspace_kind ?? 'user',
+    label: 'Signed-in workspace',
+    persistence: 'persistent',
+    summary: 'Stable author workspace bound to the authenticated identity.',
+  });
   return {
     id: buildSessionId({ kind: 'user', workspaceId }),
     kind: 'user',
@@ -135,13 +146,7 @@ function buildUserSessionFromCurrentUser(
       name: user.username,
       email: user.email,
     },
-    activeWorkspace: normalizeWorkspaceSummary(user.active_workspace, {
-      workspaceId,
-      workspaceKind: user.workspace_kind ?? 'user',
-      label: 'Signed-in workspace',
-      persistence: 'persistent',
-      summary: 'Stable author workspace bound to the authenticated identity.',
-    }),
+    activeWorkspace: preserveActiveWorkspace(previous, activeWorkspace),
     lastWorkspaceId: previous.lastWorkspaceId ?? null,
     lastJobId: previous.lastJobId ?? null,
     lastView: previous.lastView ?? 'workspace',
@@ -160,6 +165,13 @@ async function validateStoredSession(session: SessionState): Promise<SessionStat
 
   const user = await api.getCurrentUser();
   return buildUserSessionFromCurrentUser(user, session);
+}
+
+function hasSelectionField<Key extends keyof SessionSelectionUpdate>(
+  selection: SessionSelectionUpdate,
+  key: Key,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(selection, key);
 }
 
 export function AuthProvider({ children }: PropsWithChildren) {
@@ -250,21 +262,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
       throw new Error('Saved session not found.');
     }
 
-    const previousCatalog = catalogRef.current;
-    const optimisticCatalog = setActiveSessionId(previousCatalog, targetSession.id);
-    setCatalog(optimisticCatalog);
-
     try {
       const validatedSession = await validateStoredSession(targetSession);
       const nextCatalog = upsertSession(readSessionCatalog(), validatedSession);
       setCatalog(nextCatalog);
       return validatedSession;
     } catch (error) {
-      const rollbackCatalog = setActiveSessionId(
-        readSessionCatalog(),
-        previousCatalog.activeSessionId,
-      );
-      setCatalog(rollbackCatalog);
       throw error;
     }
   };
@@ -279,21 +282,25 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setCatalog(nextCatalog);
   };
 
-  const updateSessionSelection = (selection: {
-    lastWorkspaceId?: string | null;
-    lastJobId?: string | null;
-    lastView?: WorkspaceSurfaceView;
-  }) => {
+  const updateSessionSelection = (selection: SessionSelectionUpdate) => {
     const activeSession = getActiveSession(catalogRef.current);
     if (!activeSession) {
       return;
     }
 
     const nextCatalog = persistSessionSelection(catalogRef.current, activeSession.id, {
-      lastWorkspaceId:
-        selection.lastWorkspaceId ?? activeSession.lastWorkspaceId ?? null,
-      lastJobId: selection.lastJobId ?? activeSession.lastJobId ?? null,
-      lastView: selection.lastView ?? activeSession.lastView ?? 'workspace',
+      lastWorkspaceId: hasSelectionField(selection, 'lastWorkspaceId')
+        ? selection.lastWorkspaceId ?? null
+        : activeSession.lastWorkspaceId ?? null,
+      lastJobId: hasSelectionField(selection, 'lastJobId')
+        ? selection.lastJobId ?? null
+        : activeSession.lastJobId ?? null,
+      lastView: hasSelectionField(selection, 'lastView')
+        ? selection.lastView ?? 'workspace'
+        : activeSession.lastView ?? 'workspace',
+      activeWorkspace: hasSelectionField(selection, 'activeWorkspace')
+        ? selection.activeWorkspace ?? null
+        : activeSession.activeWorkspace,
     });
     setCatalog(nextCatalog);
   };

--- a/frontend/src/features/auth/LandingPage.tsx
+++ b/frontend/src/features/auth/LandingPage.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/features/auth/useAuth';
 import type { SessionState } from '@/app/types/auth';
+import { sessionDisplayMeta, sessionDisplayTitle } from './sessionDisplay';
 
 function studioLocation(session: SessionState) {
   const searchParams = new URLSearchParams();
@@ -133,10 +134,10 @@ export function LandingPage() {
                 type="button"
               >
                 <p className="text-sm font-medium">
-                  {session.activeWorkspace?.label ?? session.workspaceId}
+                  {sessionDisplayTitle(session)}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {session.user?.email ?? session.activeWorkspace?.summary ?? session.workspaceId}
+                  {sessionDisplayMeta(session)}
                 </p>
               </button>
             ))}

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/features/auth/useAuth';
 import type { SessionState } from '@/app/types/auth';
+import { sessionDisplayMeta, sessionDisplayTitle } from './sessionDisplay';
 
 function studioLocation(session: SessionState) {
   const searchParams = new URLSearchParams();
@@ -159,10 +160,10 @@ export function LoginPage() {
                 type="button"
               >
                 <p className="text-sm font-medium">
-                  {session.activeWorkspace?.label ?? session.workspaceId}
+                  {sessionDisplayTitle(session)}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {session.user?.email ?? session.activeWorkspace?.summary ?? session.workspaceId}
+                  {sessionDisplayMeta(session)}
                 </p>
               </button>
             ))}

--- a/frontend/src/features/auth/sessionDisplay.ts
+++ b/frontend/src/features/auth/sessionDisplay.ts
@@ -1,0 +1,26 @@
+import type { SessionState } from '@/app/types/auth';
+
+export function sessionDisplayTitle(session: SessionState): string {
+  if (session.activeWorkspace?.label) {
+    return session.activeWorkspace.label;
+  }
+
+  if (session.kind === 'user') {
+    return session.user?.name ?? 'Signed-in author';
+  }
+
+  return 'Guest workspace';
+}
+
+export function sessionDisplayMeta(session: SessionState): string {
+  const workspaceMeta =
+    session.activeWorkspace?.summary ??
+    session.lastWorkspaceId ??
+    session.workspaceId;
+
+  if (session.user?.email) {
+    return `${session.user.email} / ${workspaceMeta}`;
+  }
+
+  return workspaceMeta;
+}

--- a/frontend/src/features/story/StoryWorkbenchPage.test.tsx
+++ b/frontend/src/features/story/StoryWorkbenchPage.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -127,10 +127,15 @@ function makeJob(): WorkspaceJob {
   };
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return <p data-testid="location-search">{location.search || 'none'}</p>;
+}
+
 function renderWorkbench(workbench: Partial<UseStoryWorkbenchResult> = {}) {
   const createWorkspace = vi.fn().mockResolvedValue(makeWorkspace());
   const runJob = vi.fn().mockResolvedValue(makeJob());
-  vi.mocked(useAuth).mockReturnValue({
+  const auth = {
     session,
     sessions: [session],
     activeSessionId: session.id,
@@ -140,7 +145,8 @@ function renderWorkbench(workbench: Partial<UseStoryWorkbenchResult> = {}) {
     signOut: vi.fn(),
     switchSession: vi.fn(),
     updateSessionSelection: vi.fn(),
-  });
+  };
+  vi.mocked(useAuth).mockReturnValue(auth);
   vi.mocked(useStoryWorkbench).mockReturnValue({
     workspaces: [],
     activeWorkspaceId: null,
@@ -181,10 +187,11 @@ function renderWorkbench(workbench: Partial<UseStoryWorkbenchResult> = {}) {
       }}
     >
       <StoryWorkbenchPage />
+      <LocationProbe />
     </MemoryRouter>,
   );
 
-  return { createWorkspace, runJob };
+  return { auth, createWorkspace, runJob };
 }
 
 describe('StoryWorkbenchPage', () => {
@@ -279,6 +286,57 @@ describe('StoryWorkbenchPage', () => {
       await Promise.resolve();
     });
     expect(runJob).toHaveBeenCalledWith('run', { target_chapters: 3, provider: 'mock' });
+  });
+
+  it('lets the workbench hook own job URL selection after job actions', async () => {
+    const { runJob } = renderWorkbench({
+      workspaces: [makeWorkspace(3)],
+      activeWorkspaceId: 'salt-ledger',
+      workspace: makeWorkspace(3),
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('studio-review'));
+      await Promise.resolve();
+    });
+
+    expect(runJob).toHaveBeenCalledWith('review', { provider: 'mock' });
+    expect(screen.getByTestId('location-search')).toHaveTextContent('none');
+  });
+
+  it('persists selected workspace metadata from workbench selection changes', () => {
+    const selectedWorkspace = makeWorkspace(2);
+    const { auth } = renderWorkbench({
+      workspaces: [selectedWorkspace],
+      activeWorkspaceId: 'salt-ledger',
+      workspace: selectedWorkspace,
+    });
+    const options = vi.mocked(useStoryWorkbench).mock.calls[0]?.[0];
+    if (typeof options === 'string' || !options?.onSelectionChange) {
+      throw new Error('Expected object options with onSelectionChange.');
+    }
+
+    act(() => {
+      options.onSelectionChange?.({
+        workspaceId: 'salt-ledger',
+        jobId: null,
+        view: 'workspace',
+        workspace: selectedWorkspace,
+      });
+    });
+
+    expect(auth.updateSessionSelection).toHaveBeenCalledWith({
+      lastWorkspaceId: 'salt-ledger',
+      lastJobId: null,
+      lastView: 'workspace',
+      activeWorkspace: {
+        workspaceId: 'salt-ledger',
+        workspaceKind: 'guest',
+        label: 'The Salt Ledger',
+        persistence: 'ephemeral',
+        summary: 'salt-ledger / 2 chapters',
+      },
+    });
   });
 
   it('passes the selected provider to workspace jobs', async () => {

--- a/frontend/src/features/story/StoryWorkbenchPage.tsx
+++ b/frontend/src/features/story/StoryWorkbenchPage.tsx
@@ -1,17 +1,23 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
-import type { SessionState, WorkspaceSurfaceView } from '@/app/types/auth';
+import type {
+  ActiveWorkspaceSummary,
+  SessionState,
+  WorkspaceSurfaceView,
+} from '@/app/types/auth';
 import type {
   StoryGenre,
   ProviderName,
   ReviewIssue,
   WorkspaceCreateRequest,
   WorkspaceJob,
+  WorkspaceStatus,
 } from '@/app/types/story';
 import { Button } from '@/components/Button';
 import { Panel } from '@/components/Panel';
 import { StatusPill } from '@/components/StatusPill';
+import { sessionDisplayMeta, sessionDisplayTitle } from '@/features/auth/sessionDisplay';
 import { useAuth } from '@/features/auth/useAuth';
 
 import { useStoryWorkbench } from './useStoryWorkbench';
@@ -106,6 +112,33 @@ function reviewTone(blocked: boolean) {
   return blocked ? 'degraded' : 'healthy';
 }
 
+function workspacePersistenceForSession(
+  session: SessionState,
+): ActiveWorkspaceSummary['persistence'] {
+  return session.kind === 'guest' ? 'ephemeral' : 'persistent';
+}
+
+function workspaceKindForSession(
+  session: SessionState,
+): ActiveWorkspaceSummary['workspaceKind'] {
+  return session.kind === 'guest' ? 'guest' : 'user';
+}
+
+function buildActiveWorkspaceSummary(
+  session: SessionState,
+  workspace: WorkspaceStatus,
+): ActiveWorkspaceSummary {
+  const chapterLabel = workspace.chapters.length === 1 ? 'chapter' : 'chapters';
+
+  return {
+    workspaceId: workspace.workspace_id,
+    workspaceKind: workspaceKindForSession(session),
+    label: workspace.story.title,
+    persistence: workspacePersistenceForSession(session),
+    summary: `${workspace.workspace_id} / ${workspace.chapters.length} ${chapterLabel}`,
+  };
+}
+
 function issueList(issues: ReviewIssue[]) {
   if (issues.length === 0) {
     return <li className="studio-empty">No items recorded.</li>;
@@ -124,12 +157,8 @@ function issueList(issues: ReviewIssue[]) {
 }
 
 function renderSessionSummary(session: SessionState, workspaceSummary: string) {
-  const sessionTitle =
-    session.kind === 'user'
-      ? session.user?.name ?? 'Signed-in author'
-      : session.activeWorkspace?.label ?? 'Guest workspace';
-  const sessionMeta =
-    session.kind === 'user' ? session.user?.email ?? session.workspaceId : session.workspaceId;
+  const sessionTitle = sessionDisplayTitle(session);
+  const sessionMeta = sessionDisplayMeta(session);
 
   return (
     <div className="studio-session-card" data-testid="studio-session-summary">
@@ -185,19 +214,26 @@ function StoryWorkbenchContent({ auth, session }: StoryWorkbenchContentProps) {
     enabled: true,
     preferredWorkspaceId,
     preferredJobId,
-    onSelectionChange: ({ workspaceId, jobId, view }) => {
+    onSelectionChange: ({ workspaceId, jobId, view, workspace: selectedWorkspace }) => {
       auth.updateSessionSelection({
         lastWorkspaceId: workspaceId,
         lastJobId: jobId,
         lastView: view,
+        activeWorkspace: selectedWorkspace
+          ? buildActiveWorkspaceSummary(session, selectedWorkspace)
+          : workspaceId
+            ? undefined
+            : null,
       });
-      const params = new URLSearchParams(searchParams);
-      if (workspaceId) params.set('workspace', workspaceId);
-      else params.delete('workspace');
-      if (jobId) params.set('job', jobId);
-      else params.delete('job');
-      params.set('view', view);
-      setSearchParams(params, { replace: true });
+      setSearchParams((currentParams) => {
+        const params = new URLSearchParams(currentParams);
+        if (workspaceId) params.set('workspace', workspaceId);
+        else params.delete('workspace');
+        if (jobId) params.set('job', jobId);
+        else params.delete('job');
+        params.set('view', view);
+        return params;
+      }, { replace: true });
     },
   });
 
@@ -233,13 +269,15 @@ function StoryWorkbenchContent({ auth, session }: StoryWorkbenchContentProps) {
     jobId: string | null,
     view: WorkspaceSurfaceView,
   ) => {
-    const params = new URLSearchParams(searchParams);
-    if (workspaceId) params.set('workspace', workspaceId);
-    else params.delete('workspace');
-    if (jobId) params.set('job', jobId);
-    else params.delete('job');
-    params.set('view', view);
-    setSearchParams(params, { replace: true });
+    setSearchParams((currentParams) => {
+      const params = new URLSearchParams(currentParams);
+      if (workspaceId) params.set('workspace', workspaceId);
+      else params.delete('workspace');
+      if (jobId) params.set('job', jobId);
+      else params.delete('job');
+      params.set('view', view);
+      return params;
+    }, { replace: true });
   };
 
   const createWorkspace = async (event: FormEvent<HTMLFormElement>) => {
@@ -256,11 +294,10 @@ function StoryWorkbenchContent({ auth, session }: StoryWorkbenchContentProps) {
   const runWorkspace = async () => {
     setPageError(null);
     try {
-      const job = await workbench.runJob('run', {
+      await workbench.runJob('run', {
         target_chapters: formState.targetChapters,
         provider,
       });
-      setQuerySelection(workbench.activeWorkspaceId, job.job_id, 'playback');
     } catch (error) {
       setPageError(formatActionError(error, 'Unable to run the workspace.'));
     }
@@ -271,8 +308,7 @@ function StoryWorkbenchContent({ auth, session }: StoryWorkbenchContentProps) {
   ) => {
     setPageError(null);
     try {
-      const job = await workbench.runJob(operation, { provider });
-      setQuerySelection(workbench.activeWorkspaceId, job.job_id, 'playback');
+      await workbench.runJob(operation, { provider });
     } catch (error) {
       setPageError(formatActionError(error, `Unable to run ${operation}.`));
     }
@@ -351,11 +387,11 @@ function StoryWorkbenchContent({ auth, session }: StoryWorkbenchContentProps) {
                         onClick={() => void switchToSavedSession(entry.id)}
                       >
                         <div className="studio-card__header">
-                          <strong>{entry.activeWorkspace?.label ?? entry.workspaceId}</strong>
+                          <strong>{sessionDisplayTitle(entry)}</strong>
                           <span>{entry.kind}</span>
                         </div>
                         <p className="studio-card__meta">
-                          {entry.user?.email ?? entry.workspaceId}
+                          {sessionDisplayMeta(entry)}
                         </p>
                       </button>
                     </li>

--- a/frontend/src/features/story/useStoryWorkbench.test.tsx
+++ b/frontend/src/features/story/useStoryWorkbench.test.tsx
@@ -7,7 +7,11 @@ import type { WorkspaceJob, WorkspaceStatus } from '@/app/types/story';
 import { render, screen, waitFor } from '../../../tests/test-utils';
 import { useStoryWorkbench } from './useStoryWorkbench';
 
-function makeWorkspace(id = 'salt-ledger', chapters = 0): WorkspaceStatus {
+function makeWorkspace(
+  id = 'salt-ledger',
+  chapters = 0,
+  jobs: WorkspaceJob[] = [],
+): WorkspaceStatus {
   return {
     workspace_id: id,
     story: {
@@ -30,16 +34,18 @@ function makeWorkspace(id = 'salt-ledger', chapters = 0): WorkspaceStatus {
     latest_review: null,
     exports: [],
     runs: [],
-    jobs: [],
+    jobs,
   };
 }
 
-function makeJob(status: WorkspaceJob['status'] = 'completed'): WorkspaceJob {
+function makeJob(
+  status: WorkspaceJob['status'] = 'completed',
+  overrides: Partial<WorkspaceJob> = {},
+): WorkspaceJob {
   return {
     job_id: 'job-1',
     workspace_id: 'salt-ledger',
     operation: 'run',
-    status,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:01Z',
     provider: 'mock',
@@ -59,6 +65,8 @@ function makeJob(status: WorkspaceJob['status'] = 'completed'): WorkspaceJob {
     error: null,
     failure_artifact: null,
     events: [],
+    ...overrides,
+    status,
   };
 }
 
@@ -94,10 +102,25 @@ function mockProviders() {
   });
 }
 
-function Harness() {
+function Harness({
+  onSelectionChange = vi.fn(),
+  preferredWorkspaceId,
+  preferredJobId,
+}: {
+  onSelectionChange?: (selection: {
+    workspaceId: string | null;
+    jobId: string | null;
+    view: 'workspace' | 'playback';
+    workspace?: WorkspaceStatus | null;
+  }) => void;
+  preferredWorkspaceId?: string | null;
+  preferredJobId?: string | null;
+}) {
   const workbench = useStoryWorkbench({
     authorId: 'workspace-123',
-    onSelectionChange: vi.fn(),
+    preferredWorkspaceId,
+    preferredJobId,
+    onSelectionChange,
   });
 
   return (
@@ -105,6 +128,11 @@ function Harness() {
       <p data-testid="count">{workbench.workspaces.length}</p>
       <p data-testid="active">{workbench.activeWorkspaceId ?? 'none'}</p>
       <p data-testid="job">{workbench.currentJob?.status ?? 'none'}</p>
+      <p data-testid="job-label">
+        {workbench.currentJob
+          ? `${workbench.currentJob.operation} ${workbench.currentJob.status}`
+          : 'none'}
+      </p>
       <p data-testid="busy">{workbench.isBusy ? 'busy' : 'idle'}</p>
       <p data-testid="error">{workbench.error ?? 'none'}</p>
       <button
@@ -129,6 +157,15 @@ function Harness() {
         }
       >
         run
+      </button>
+      <button
+        type="button"
+        data-testid="review"
+        onClick={() =>
+          void workbench.runJob('review').catch(() => undefined)
+        }
+      >
+        review
       </button>
       <button
         type="button"
@@ -208,6 +245,213 @@ describe('useStoryWorkbench', () => {
       'job-1',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
+  });
+
+  it('reconciles quick review completion from refreshed workspace status', async () => {
+    mockProviders();
+    const selectionSpy = vi.fn();
+    const queuedReview = makeJob('queued', {
+      job_id: 'review-1',
+      operation: 'review',
+      result: null,
+    });
+    const completedReview = makeJob('completed', {
+      job_id: 'review-1',
+      operation: 'review',
+      result: {
+        result_type: 'review',
+        review: {
+          story_title: 'The Salt Ledger',
+          checked_at: '2026-01-01T00:00:01Z',
+          blockers: [],
+          warnings: [],
+          suggestions: [],
+          style_notes: [],
+          export_blocked: false,
+        },
+      },
+    });
+    const completedWorkspace = makeWorkspace('salt-ledger', 1, [completedReview]);
+    vi.spyOn(api, 'listWorkspaces').mockResolvedValue({
+      workspaces: [makeWorkspace('salt-ledger', 1)],
+    });
+    vi.spyOn(api, 'createWorkspaceJob').mockResolvedValue(queuedReview);
+    vi.spyOn(api, 'getWorkspaceJob').mockResolvedValue(queuedReview);
+    vi.spyOn(api, 'getWorkspace').mockResolvedValue(completedWorkspace);
+
+    render(<Harness onSelectionChange={selectionSpy} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId('active')).toHaveTextContent('salt-ledger'));
+
+    await act(async () => {
+      screen.getByTestId('review').click();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('job-label')).toHaveTextContent('review completed'),
+    );
+    expect(selectionSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        workspaceId: 'salt-ledger',
+        jobId: 'review-1',
+        view: 'playback',
+        workspace: completedWorkspace,
+      }),
+    );
+    expect(selectionSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'review-1',
+        workspace: undefined,
+      }),
+    );
+    expect(api.getWorkspaceJob).toHaveBeenCalledWith(
+      'salt-ledger',
+      'review-1',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(api.getWorkspace).toHaveBeenCalledWith(
+      'salt-ledger',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('resumes polling a non-terminal preferred review job from the library', async () => {
+    mockProviders();
+    const selectionSpy = vi.fn();
+    const queuedReview = makeJob('running', {
+      job_id: 'review-resume-1',
+      operation: 'review',
+      result: null,
+    });
+    const completedReview = makeJob('completed', {
+      job_id: 'review-resume-1',
+      operation: 'review',
+      result: {
+        result_type: 'review',
+        review: {
+          story_title: 'The Salt Ledger',
+          checked_at: '2026-01-01T00:00:01Z',
+          blockers: [],
+          warnings: [],
+          suggestions: [],
+          style_notes: [],
+          export_blocked: false,
+        },
+      },
+    });
+    const completedWorkspace = makeWorkspace('salt-ledger', 1, [completedReview]);
+    const listWorkspacesSpy = vi.spyOn(api, 'listWorkspaces').mockResolvedValue({
+      workspaces: [makeWorkspace('salt-ledger', 1, [queuedReview])],
+    });
+    vi.spyOn(api, 'getWorkspaceJob').mockResolvedValue(completedReview);
+    vi.spyOn(api, 'getWorkspace').mockResolvedValue(completedWorkspace);
+
+    render(
+      <Harness
+        onSelectionChange={selectionSpy}
+        preferredWorkspaceId="salt-ledger"
+        preferredJobId="review-resume-1"
+      />,
+    );
+
+    await waitFor(() => expect(listWorkspacesSpy).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByTestId('job-label')).toHaveTextContent('review completed'),
+    );
+    expect(api.getWorkspaceJob).toHaveBeenCalledWith(
+      'salt-ledger',
+      'review-resume-1',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(selectionSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        workspaceId: 'salt-ledger',
+        jobId: 'review-resume-1',
+        view: 'playback',
+        workspace: completedWorkspace,
+      }),
+    );
+  });
+
+  it('continues polling through a transient workspace refresh failure', async () => {
+    mockProviders();
+    const queuedReview = makeJob('queued', {
+      job_id: 'review-transient-1',
+      operation: 'review',
+      result: null,
+    });
+    const completedReview = makeJob('completed', {
+      job_id: 'review-transient-1',
+      operation: 'review',
+      result: {
+        result_type: 'review',
+        review: {
+          story_title: 'The Salt Ledger',
+          checked_at: '2026-01-01T00:00:01Z',
+          blockers: [],
+          warnings: [],
+          suggestions: [],
+          style_notes: [],
+          export_blocked: false,
+        },
+      },
+    });
+    const completedWorkspace = makeWorkspace('salt-ledger', 1, [completedReview]);
+    vi.spyOn(api, 'listWorkspaces').mockResolvedValue({
+      workspaces: [makeWorkspace('salt-ledger', 1)],
+    });
+    vi.spyOn(api, 'createWorkspaceJob').mockResolvedValue(queuedReview);
+    vi.spyOn(api, 'getWorkspaceJob').mockResolvedValue(queuedReview);
+    vi.spyOn(api, 'getWorkspace')
+      .mockRejectedValueOnce(new Error('Service temporarily unavailable. Start the backend API and retry.'))
+      .mockResolvedValue(completedWorkspace);
+
+    render(<Harness />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId('active')).toHaveTextContent('salt-ledger'));
+
+    await act(async () => {
+      screen.getByTestId('review').click();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('job-label')).toHaveTextContent('review completed'),
+    );
+    expect(screen.getByTestId('error')).toHaveTextContent('none');
+  });
+
+  it('does not downgrade a terminal polled job with a stale workspace snapshot', async () => {
+    mockProviders();
+    const queuedRun = makeJob('queued', { job_id: 'run-1' });
+    const completedRun = makeJob('completed', { job_id: 'run-1' });
+    const staleRunningRun = makeJob('running', { job_id: 'run-1' });
+    vi.spyOn(api, 'listWorkspaces').mockResolvedValue({
+      workspaces: [makeWorkspace()],
+    });
+    vi.spyOn(api, 'createWorkspaceJob').mockResolvedValue(queuedRun);
+    vi.spyOn(api, 'getWorkspaceJob').mockResolvedValue(completedRun);
+    vi.spyOn(api, 'getWorkspace').mockResolvedValue(
+      makeWorkspace('salt-ledger', 3, [staleRunningRun]),
+    );
+
+    render(<Harness />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId('active')).toHaveTextContent('salt-ledger'));
+
+    await act(async () => {
+      screen.getByTestId('run').click();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('job-label')).toHaveTextContent('run completed'),
+    );
+    expect(screen.getByTestId('busy')).toHaveTextContent('idle');
   });
 
   it('cancels stale polling when switching workspaces', async () => {

--- a/frontend/src/features/story/useStoryWorkbench.ts
+++ b/frontend/src/features/story/useStoryWorkbench.ts
@@ -47,6 +47,7 @@ interface UseStoryWorkbenchOptions {
     workspaceId: string | null;
     jobId: string | null;
     view: WorkspaceSurfaceView;
+    workspace?: WorkspaceStatus | null;
   }) => void;
 }
 
@@ -99,6 +100,35 @@ function upsertWorkspace(
   return nextWorkspaces;
 }
 
+function findWorkspaceJob(
+  workspace: WorkspaceStatus,
+  jobId: string,
+): WorkspaceJob | null {
+  return workspace.jobs.find((job) => job.job_id === jobId) ?? null;
+}
+
+function resolveWorkspaceJob(
+  workspace: WorkspaceStatus,
+  job: WorkspaceJob | null,
+): WorkspaceJob | null {
+  if (!job) {
+    return workspace.jobs[0] ?? null;
+  }
+
+  const workspaceJob = findWorkspaceJob(workspace, job.job_id);
+  if (!workspaceJob) {
+    return job;
+  }
+  if (isTerminalJob(job) && !isTerminalJob(workspaceJob)) {
+    return job;
+  }
+  return workspaceJob;
+}
+
+function isTerminalJob(job: WorkspaceJob): boolean {
+  return TERMINAL_JOB_STATUSES.has(job.status);
+}
+
 export function useStoryWorkbench(
   authorIdOrOptions: string | UseStoryWorkbenchOptions,
 ): UseStoryWorkbenchResult {
@@ -122,6 +152,7 @@ export function useStoryWorkbench(
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const activeWorkspaceIdRef = useRef<string | null>(null);
+  const workspaceRef = useRef<WorkspaceStatus | null>(null);
   const preferredWorkspaceIdRef = useRef<string | null>(preferredWorkspaceId ?? null);
   const preferredJobIdRef = useRef<string | null>(preferredJobId ?? null);
   const onSelectionChangeRef = useRef(onSelectionChange);
@@ -152,11 +183,17 @@ export function useStoryWorkbench(
   );
 
   const notifySelection = useCallback(
-    (workspaceId: string | null, jobId: string | null, view: WorkspaceSurfaceView) => {
+    (
+      workspaceId: string | null,
+      jobId: string | null,
+      view: WorkspaceSurfaceView,
+      workspace?: WorkspaceStatus | null,
+    ) => {
       onSelectionChangeRef.current?.({
         workspaceId,
         jobId,
         view,
+        workspace,
       });
     },
     [],
@@ -168,18 +205,110 @@ export function useStoryWorkbench(
     runTokenRef.current += 1;
   }, []);
 
+  const pollJobToTerminal = useCallback(
+    async (
+      workspaceId: string,
+      initialJob: WorkspaceJob,
+      pollController: AbortController,
+      isCurrentRun: () => boolean,
+    ) => {
+      let polledJob = initialJob;
+      let terminalWorkspace: WorkspaceStatus | null = null;
+      let lastPollError: unknown = null;
+
+      for (let attempt = 0; attempt < JOB_POLL_MAX_ATTEMPTS; attempt += 1) {
+        if (isTerminalJob(polledJob)) {
+          break;
+        }
+        await delay(attempt === 0 ? 0 : JOB_POLL_INTERVAL_MS, pollController.signal);
+        try {
+          polledJob = await api.getWorkspaceJob(
+            workspaceId,
+            initialJob.job_id,
+            { signal: pollController.signal },
+          );
+          lastPollError = null;
+          if (isCurrentRun()) {
+            setCurrentJob(polledJob);
+          }
+          if (!isTerminalJob(polledJob)) {
+            const refreshedWorkspace = await api.getWorkspace(workspaceId, {
+              signal: pollController.signal,
+            });
+            const workspaceJob = findWorkspaceJob(refreshedWorkspace, initialJob.job_id);
+            if (workspaceJob) {
+              polledJob = workspaceJob;
+              lastPollError = null;
+              if (isCurrentRun()) {
+                setCurrentJob(workspaceJob);
+              }
+              if (isTerminalJob(workspaceJob)) {
+                terminalWorkspace = refreshedWorkspace;
+              }
+            }
+          }
+        } catch (pollError) {
+          if (isCancelledRequest(pollError)) {
+            throw pollError;
+          }
+          lastPollError = pollError;
+          const refreshedWorkspace = await api.getWorkspace(workspaceId, {
+            signal: pollController.signal,
+          }).catch((refreshError: unknown) => {
+            if (isCancelledRequest(refreshError)) {
+              throw refreshError;
+            }
+            lastPollError = refreshError;
+            return null;
+          });
+          const workspaceJob = refreshedWorkspace
+            ? findWorkspaceJob(refreshedWorkspace, initialJob.job_id)
+            : null;
+          if (workspaceJob) {
+            polledJob = workspaceJob;
+            lastPollError = null;
+            if (isCurrentRun()) {
+              setCurrentJob(workspaceJob);
+            }
+            if (isTerminalJob(workspaceJob)) {
+              terminalWorkspace = refreshedWorkspace;
+            }
+          }
+        }
+      }
+
+      if (!isTerminalJob(polledJob)) {
+        if (lastPollError) {
+          throw lastPollError;
+        }
+        throw new Error(`Job ${initialJob.job_id} did not finish before polling timed out.`);
+      }
+
+      const nextWorkspace =
+        terminalWorkspace ??
+        (await api.getWorkspace(workspaceId, {
+          signal: pollController.signal,
+        }));
+      const resolvedJob = resolveWorkspaceJob(nextWorkspace, polledJob);
+      return { nextWorkspace, resolvedJob, polledJob };
+    },
+    [],
+  );
+
   const syncWorkspace = useCallback(
     (nextWorkspace: WorkspaceStatus, job: WorkspaceJob | null = null) => {
       setWorkspaces((current) => upsertWorkspace(current, nextWorkspace));
       setWorkspace(nextWorkspace);
       setActiveWorkspaceId(nextWorkspace.workspace_id);
       activeWorkspaceIdRef.current = nextWorkspace.workspace_id;
-      const nextJob = job ?? nextWorkspace.jobs[0] ?? null;
+      workspaceRef.current = nextWorkspace;
+      const nextJob = resolveWorkspaceJob(nextWorkspace, job);
       setCurrentJob(nextJob);
       notifySelection(
         nextWorkspace.workspace_id,
         nextJob?.job_id ?? null,
         nextJob ? 'playback' : 'workspace',
+        nextWorkspace,
       );
     },
     [notifySelection],
@@ -213,19 +342,17 @@ export function useStoryWorkbench(
       if (!selectedWorkspace) {
         setWorkspace(null);
         setActiveWorkspaceId(null);
+        activeWorkspaceIdRef.current = null;
+        workspaceRef.current = null;
         setCurrentJob(null);
-        notifySelection(null, null, 'workspace');
+        notifySelection(null, null, 'workspace', null);
         return;
       }
 
-      syncWorkspace(selectedWorkspace);
       const preferredJob = preferredJobIdRef.current
         ? selectedWorkspace.jobs.find((job) => job.job_id === preferredJobIdRef.current)
         : null;
-      if (preferredJob) {
-        setCurrentJob(preferredJob);
-        notifySelection(selectedWorkspace.workspace_id, preferredJob.job_id, 'playback');
-      }
+      syncWorkspace(selectedWorkspace, preferredJob);
     } catch (nextError) {
       setError(formatError(nextError, 'Unable to load local workspaces.'));
     } finally {
@@ -300,39 +427,21 @@ export function useStoryWorkbench(
         });
         if (isCurrentRun()) {
           setCurrentJob(createdJob);
-          notifySelection(workspaceId, createdJob.job_id, 'playback');
         }
 
-        let polledJob = createdJob;
-        for (let attempt = 0; attempt < JOB_POLL_MAX_ATTEMPTS; attempt += 1) {
-          if (TERMINAL_JOB_STATUSES.has(polledJob.status)) {
-            break;
-          }
-          await delay(attempt === 0 ? 0 : JOB_POLL_INTERVAL_MS, pollController.signal);
-          polledJob = await api.getWorkspaceJob(
-            workspaceId,
-            createdJob.job_id,
-            { signal: pollController.signal },
-          );
-          if (isCurrentRun()) {
-            setCurrentJob(polledJob);
-          }
-        }
-
-        if (!TERMINAL_JOB_STATUSES.has(polledJob.status)) {
-          throw new Error(`Job ${createdJob.job_id} did not finish before polling timed out.`);
-        }
-
-        const nextWorkspace = await api.getWorkspace(workspaceId, {
-          signal: pollController.signal,
-        });
+        const { nextWorkspace, resolvedJob, polledJob } = await pollJobToTerminal(
+          workspaceId,
+          createdJob,
+          pollController,
+          isCurrentRun,
+        );
         if (
           isCurrentRun() &&
           activeWorkspaceIdRef.current === workspaceId
         ) {
-          syncWorkspace(nextWorkspace, polledJob);
+          syncWorkspace(nextWorkspace, resolvedJob);
         }
-        return polledJob;
+        return resolvedJob ?? polledJob;
       } catch (nextError) {
         if (isCancelledRequest(nextError)) {
           throw nextError;
@@ -346,8 +455,63 @@ export function useStoryWorkbench(
         }
       }
     },
-    [notifySelection, syncWorkspace],
+    [pollJobToTerminal, syncWorkspace],
   );
+
+  useEffect(() => {
+    if (!enabled || !workspace || !currentJob || isTerminalJob(currentJob)) {
+      return undefined;
+    }
+    if (pollControllerRef.current) {
+      return undefined;
+    }
+
+    const workspaceId = workspace.workspace_id;
+    const jobToResume = currentJob;
+    const pollController = new AbortController();
+    const runToken = runTokenRef.current + 1;
+    runTokenRef.current = runToken;
+    pollControllerRef.current = pollController;
+    const isCurrentRun = () =>
+      pollControllerRef.current === pollController && runTokenRef.current === runToken;
+
+    setIsBusy(true);
+    setError(null);
+
+    void pollJobToTerminal(workspaceId, jobToResume, pollController, isCurrentRun)
+      .then(({ nextWorkspace, resolvedJob }) => {
+        if (
+          isCurrentRun() &&
+          activeWorkspaceIdRef.current === workspaceId
+        ) {
+          syncWorkspace(nextWorkspace, resolvedJob);
+        }
+      })
+      .catch((nextError) => {
+        if (isCancelledRequest(nextError)) {
+          return;
+        }
+        setError(formatError(nextError, `Unable to poll ${jobToResume.operation}.`));
+      })
+      .finally(() => {
+        if (isCurrentRun()) {
+          pollControllerRef.current = null;
+          setIsBusy(false);
+        }
+      });
+
+    return () => {
+      if (pollControllerRef.current === pollController) {
+        pollController.abort();
+      }
+    };
+  }, [
+    currentJob?.job_id,
+    enabled,
+    pollJobToTerminal,
+    syncWorkspace,
+    workspace?.workspace_id,
+  ]);
 
   return useMemo(
     () => ({

--- a/frontend/src/shared/storage.test.ts
+++ b/frontend/src/shared/storage.test.ts
@@ -22,6 +22,7 @@ function makeSession(
     kind: overrides.kind,
     workspaceId: overrides.workspaceId,
     user: overrides.user,
+    activeWorkspace: overrides.activeWorkspace,
     lastWorkspaceId: overrides.lastWorkspaceId ?? null,
     lastJobId: overrides.lastJobId ?? null,
     lastView: overrides.lastView ?? 'workspace',
@@ -121,13 +122,57 @@ describe('session storage catalog', () => {
       lastWorkspaceId: 'workspace-new',
       lastJobId: null,
       lastView: 'workspace',
+      activeWorkspace: {
+        workspaceId: 'workspace-new',
+        workspaceKind: 'guest',
+        label: 'The Salt Ledger',
+        persistence: 'ephemeral',
+        summary: 'workspace-new / 1 chapter',
+      },
     });
 
     expect(getActiveSession(nextCatalog)).toMatchObject({
       lastWorkspaceId: 'workspace-new',
       lastJobId: null,
       lastView: 'workspace',
+      activeWorkspace: {
+        workspaceId: 'workspace-new',
+        label: 'The Salt Ledger',
+        summary: 'workspace-new / 1 chapter',
+      },
     });
+  });
+
+  it('clears selection metadata when null patches are explicit', () => {
+    const session = makeSession({
+      kind: 'guest',
+      workspaceId: 'guest-1',
+      activeWorkspace: {
+        workspaceId: 'workspace-old',
+        workspaceKind: 'guest',
+        label: 'Old Story',
+        persistence: 'ephemeral',
+        summary: 'workspace-old / 3 chapters',
+      },
+      lastWorkspaceId: 'workspace-old',
+      lastJobId: 'job-old',
+      lastView: 'playback',
+    });
+    const catalog = upsertSession(emptySessionCatalog(), session);
+
+    const nextCatalog = updateSessionSelection(catalog, session.id, {
+      lastWorkspaceId: null,
+      lastJobId: null,
+      lastView: 'workspace',
+      activeWorkspace: null,
+    });
+
+    expect(getActiveSession(nextCatalog)).toMatchObject({
+      lastWorkspaceId: null,
+      lastJobId: null,
+      lastView: 'workspace',
+    });
+    expect(getActiveSession(nextCatalog)?.activeWorkspace).toBeUndefined();
   });
 
   it('removes sessions and deactivates the removed active session', () => {

--- a/frontend/src/shared/storage.ts
+++ b/frontend/src/shared/storage.ts
@@ -1,4 +1,4 @@
-import type { SessionCatalog, SessionState } from '@/app/types/auth';
+import type { SessionCatalog, SessionSelectionUpdate, SessionState } from '@/app/types/auth';
 
 const sessionCatalogStorageKey = 'novel-engine-session-catalog';
 const SESSION_CATALOG_VERSION = 3;
@@ -78,6 +78,13 @@ function normalizeSession(session: SessionState): SessionState {
     lastJobId: catalogSession.lastJobId ?? null,
     lastView: catalogSession.lastView ?? 'workspace',
   };
+}
+
+function hasPatchField<Key extends keyof SessionSelectionUpdate>(
+  patch: SessionSelectionUpdate,
+  key: Key,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(patch, key);
 }
 
 export function emptySessionCatalog(): SessionCatalog {
@@ -168,13 +175,24 @@ export function removeSession(
 export function updateSessionSelection(
   catalog: SessionCatalog,
   sessionId: string,
-  patch: Pick<SessionState, 'lastWorkspaceId' | 'lastJobId' | 'lastView'>,
+  patch: SessionSelectionUpdate,
 ): SessionCatalog {
   const sessions = catalog.sessions.map((session) =>
     session.id === sessionId
       ? normalizeSession({
           ...session,
-          ...patch,
+          lastWorkspaceId: hasPatchField(patch, 'lastWorkspaceId')
+            ? patch.lastWorkspaceId ?? null
+            : session.lastWorkspaceId ?? null,
+          lastJobId: hasPatchField(patch, 'lastJobId')
+            ? patch.lastJobId ?? null
+            : session.lastJobId ?? null,
+          lastView: hasPatchField(patch, 'lastView')
+            ? patch.lastView ?? 'workspace'
+            : session.lastView ?? 'workspace',
+          activeWorkspace: hasPatchField(patch, 'activeWorkspace')
+            ? patch.activeWorkspace ?? undefined
+            : session.activeWorkspace,
           updatedAt: nowIso(),
         })
       : normalizeSession(session),

--- a/frontend/tests/e2e/frontend-full-audit.spec.ts
+++ b/frontend/tests/e2e/frontend-full-audit.spec.ts
@@ -46,10 +46,17 @@ test.describe('frontend full audit', () => {
 
     await launchGuest(page);
     const guestWorkspace = (await page.getByTestId('workspace-badge').textContent())?.trim() ?? '';
+    const guestTitle = uniqueTitle('Audit Guest Resume Story');
+    await seedDraftStory(page, {
+      title: guestTitle,
+      premise: 'A clockmaker hides a treaty in a public bell before the city forgets its own laws.',
+      targetChapters: 1,
+    });
 
     await page.getByTestId('studio-back-to-landing').click();
     await expect(page.getByTestId('auth-home-page')).toBeVisible();
     await expect(page.getByTestId('auth-home-session-catalog')).toBeVisible();
+    await expect(page.getByTestId('auth-home-session-catalog')).toContainText(guestTitle);
     await page.getByTestId('auth-home-go-login').click();
 
     await page.getByTestId('auth-login-email').fill('operator@novel.engine');
@@ -58,14 +65,18 @@ test.describe('frontend full audit', () => {
     await expect(page.getByTestId('workspace-badge')).toContainText('user-');
 
     await expect(page.getByTestId('session-switcher')).toBeVisible();
-    await page.getByRole('button', { name: /guest workspace/i }).click();
+    await expect(page.getByTestId('session-switcher')).toContainText(guestTitle);
+    await page.getByRole('button', { name: new RegExp(guestTitle, 'i') }).click();
     await expectStudioRoute(page);
     await expect(page.getByTestId('workspace-badge')).toHaveText(guestWorkspace);
+    await expect(page.getByTestId('studio-active-title')).toHaveText(guestTitle);
 
     await page.getByTestId('studio-back-to-landing').click();
+    await expect(page.getByTestId('auth-home-session-catalog')).toContainText(guestTitle);
     await page.getByTestId(`auth-home-resume-session-guest:${guestWorkspace}`).click();
     await expectStudioRoute(page);
     await expect(page.getByTestId('workspace-badge')).toHaveText(guestWorkspace);
+    await expect(page.getByTestId('studio-active-title')).toHaveText(guestTitle);
 
     await assertConsoleClean();
   });

--- a/src/apps/api/dependencies.py
+++ b/src/apps/api/dependencies.py
@@ -266,6 +266,12 @@ async def get_workspace_principal(
     current_user: CurrentUser | None = Depends(get_current_user_optional),
 ) -> WorkspacePrincipal | None:
     """Resolve the current workspace principal from user auth or guest cookie."""
+    from src.apps.api.routes.guest import GUEST_SESSION_COOKIE
+
+    guest_workspace = request.cookies.get(GUEST_SESSION_COOKIE)
+    if isinstance(guest_workspace, str) and guest_workspace.startswith("guest-"):
+        return WorkspacePrincipal(kind="guest", workspace_id=guest_workspace)
+
     if current_user and current_user.username:
         return WorkspacePrincipal(
             kind="user",
@@ -276,12 +282,6 @@ async def get_workspace_principal(
             user_id=current_user.user_id,
             username=current_user.username,
         )
-
-    from src.apps.api.routes.guest import GUEST_SESSION_COOKIE
-
-    guest_workspace = request.cookies.get(GUEST_SESSION_COOKIE)
-    if isinstance(guest_workspace, str) and guest_workspace.startswith("guest-"):
-        return WorkspacePrincipal(kind="guest", workspace_id=guest_workspace)
     return None
 
 

--- a/src/apps/api/routes/workspaces.py
+++ b/src/apps/api/routes/workspaces.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import re
 import threading
+import time
 import traceback
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -439,7 +440,14 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
-    temp_path.replace(path)
+    for attempt in range(6):
+        try:
+            temp_path.replace(path)
+            return
+        except PermissionError:
+            if attempt == 5:
+                raise
+            time.sleep(0.05 * (attempt + 1))
 
 
 def _job_path(workspace: NovelWorkspace, job_id: str) -> Path:

--- a/src/contexts/identity/interface/http/auth_router.py
+++ b/src/contexts/identity/interface/http/auth_router.py
@@ -367,6 +367,7 @@ async def logout(
     description="Get information about the currently authenticated user.",
 )
 async def get_current_user_info(
+    response: Response,
     user: CurrentUser = Depends(get_current_user),
 ) -> CurrentUserResponse:
     """Get current user information.
@@ -378,6 +379,7 @@ async def get_current_user_info(
         UserResponse containing user information.
     """
     workspace_id = user_workspace_id(user_id=user.user_id, username=user.username)
+    _set_workspace_cookie(response, workspace_id)
     return CurrentUserResponse(
         id=user.user_id,
         username=user.username,

--- a/tests/apps/api/test_auth.py
+++ b/tests/apps/api/test_auth.py
@@ -139,6 +139,69 @@ def test_guest_launch_does_not_reuse_user_workspace_cookie(
     assert payload["workspace_id"] != user_workspace_id
 
 
+def test_guest_workspace_cookie_selects_guest_then_me_restores_user_workspace(
+    canonical_client: Any,
+) -> None:
+    login_response = canonical_client.post(
+        "/api/auth/login",
+        json={
+            "email": "operator@novel.engine",
+            "password": "demo-password",
+        },
+    )
+    assert login_response.status_code == 200
+    user_workspace_id = login_response.json()["workspace_id"]
+
+    user_workspace_response = canonical_client.post(
+        "/api/workspaces",
+        json={
+            "workspace_id": "user-cookie-story",
+            "title": "User Cookie Story",
+            "genre": "fantasy",
+            "premise": "A signed-in author keeps one manuscript in the persistent library.",
+            "target_chapters": 1,
+        },
+    )
+    assert user_workspace_response.status_code == 201
+
+    guest_response = canonical_client.post("/api/guest/session")
+    assert guest_response.status_code == 200
+    guest_workspace_id = guest_response.json()["workspace_id"]
+    assert guest_workspace_id.startswith("guest-")
+    assert guest_workspace_id != user_workspace_id
+
+    guest_workspace_response = canonical_client.post(
+        "/api/workspaces",
+        json={
+            "workspace_id": "guest-cookie-story",
+            "title": "Guest Cookie Story",
+            "genre": "mystery",
+            "premise": "A guest author keeps a separate disposable manuscript.",
+            "target_chapters": 1,
+        },
+    )
+    assert guest_workspace_response.status_code == 201
+
+    guest_list_response = canonical_client.get("/api/workspaces")
+    assert guest_list_response.status_code == 200
+    assert [
+        workspace["workspace_id"]
+        for workspace in guest_list_response.json()["workspaces"]
+    ] == ["guest-cookie-story"]
+
+    current_response = canonical_client.get("/api/auth/me")
+    assert current_response.status_code == 200
+    assert current_response.json()["workspace_id"] == user_workspace_id
+    assert f"novel_engine_workspace={user_workspace_id}" in current_response.headers["set-cookie"]
+
+    user_list_response = canonical_client.get("/api/workspaces")
+    assert user_list_response.status_code == 200
+    assert [
+        workspace["workspace_id"]
+        for workspace in user_list_response.json()["workspaces"]
+    ] == ["user-cookie-story"]
+
+
 def test_login_with_invalid_credentials_returns_401(
     canonical_client: Any,
 ) -> None:

--- a/tests/apps/api/test_workspaces.py
+++ b/tests/apps/api/test_workspaces.py
@@ -12,6 +12,33 @@ from src.shared.infrastructure.config.settings import get_settings
 TERMINAL_JOB_STATUSES = {"completed", "failed", "interrupted"}
 
 
+def test_atomic_write_json_retries_transient_permission_error(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    import src.apps.api.routes.workspaces as workspace_routes
+
+    target_path = tmp_path / "job.json"
+    replace_calls = 0
+    original_replace = Path.replace
+
+    def flaky_replace(self: Path, target: Path | str) -> Path:
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 1:
+            raise PermissionError("target is briefly locked")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", flaky_replace)
+
+    workspace_routes._atomic_write_json(target_path, {"status": "completed"})
+
+    assert replace_calls == 2
+    assert json.loads(target_path.read_text(encoding="utf-8")) == {
+        "status": "completed"
+    }
+
+
 def _start_guest(canonical_client: Any, workspace_id: str | None = None) -> str:
     payload = {"workspace_id": workspace_id} if workspace_id else None
     response = canonical_client.post("/api/guest/session", json=payload)


### PR DESCRIPTION
## Summary
- Fix Story Workbench job lifecycle ownership so review/export/revise jobs reconcile from fresh workspace state after terminal polling.
- Preserve active workspace metadata in saved sessions and session switching so guest/user catalogs show story identity instead of generic labels.
- Add focused unit, API, and E2E regression coverage for review completion, session metadata persistence, and session switching.

## Root Cause
Browser UAT showed fast Review jobs could finish on disk while the UI stayed queued/running because page-level URL/session writes raced with hook-owned polling state. A second issue came from session validation rebuilding active workspace summaries from generic identity metadata, overwriting the concrete story workspace title.

## Validation
- pytest tests/apps/api
- npm --prefix frontend run type-check
- npm --prefix frontend run test
- npm --prefix frontend run test:e2e:smoke
- npm --prefix frontend run test:e2e:full-audit
- Live Browser UAT against http://127.0.0.1:4273 with E2E_LLM_PROVIDER=dashscope
- Push hook also passed mypy, import-linter, backend pytest, OpenAPI snapshot, API public audit, frontend type-check/test/build, frontend e2e smoke/full-audit, frontend dependency audit, and frontend export audit.

## Browser UAT Evidence
- Guest principal: guest-b0ba6af823d8; workspace fresh-browser-guest-mq66hwbo-1103b6aa.
- Guest jobs completed through UI: run 62b2df1c-c433-4588-b994-bdfc51fbdc46, review 7c0f492e-8694-4a74-89cc-ca489fbcdecb, export f450fafe-fb81-4df3-962c-6f121edf9529.
- Signed principal: user-5573d7ac-a767-44e6-9319-ead4065993bf; workspace fresh-browser-signed-mq67f4xf-6fb91c32.
- Signed jobs completed through UI: draft c9c7702f-10c8-4698-914d-0b1ebd16f809, review 2f79b05f-d9e8-49b1-8c58-398ba0cd9760, revise aaa05c0c-f636-4078-ada3-f01dc0225b8e, export d89049ed-7209-4d36-8cd2-536b9205c721.
