### PR TITLE
[codex] modernize Node and pnpm CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: true
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.4
         with:
           version: 11.6.0
       - uses: actions/setup-node@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,15 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: python
-            category: .github/workflows/codeql.yml:analyze/language:python
-          - language: python
-            category: /language:python
-          - language: javascript-typescript
-            category: .github/workflows/codeql.yml:analyze/language:javascript-typescript
-          - language: javascript-typescript
-            category: /language:javascript
+        language: [python, javascript-typescript]
 
     steps:
       - name: Checkout
@@ -69,26 +61,25 @@ jobs:
         if: matrix.language == 'python'
         run: uv sync --extra dev --extra test --frozen
 
+      - name: Set up pnpm
+        if: matrix.language == 'javascript-typescript'
+        uses: pnpm/action-setup@v6.0.4
+        with:
+          version: 11.6.0
+
       - name: Set up Node
         if: matrix.language == 'javascript-typescript'
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: pnpm
 
       - name: Install frontend dependencies
         if: matrix.language == 'javascript-typescript'
-        working-directory: frontend
-        run: |
-          if [ -f package-lock.json ]; then
-            npm ci
-          else
-            npm install
-          fi
+        run: pnpm install --frozen-lockfile
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4
 
       - name: Analyze
         uses: github/codeql-action/analyze@v4
-        with:
-          category: ${{ matrix.category }}


### PR DESCRIPTION
## Summary
- upgrade pnpm/action-setup to v6.0.4 for the Node 24 action runtime
- run CodeQL once per supported language instead of duplicate category jobs
- align JavaScript analysis with Node 22, pnpm 11.6.0, and the root frozen lockfile

## Validation
- pre-commit hooks passed
- backend pytest passed
- OpenAPI snapshot passed
- frontend type-check, tests, and build passed