### PR TITLE
ci: add cache-suffix to setup-uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: true
+          cache-suffix: ci
       - uses: pnpm/action-setup@v6.0.4
         with:
           version: 11.6.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
+          cache-suffix: codeql
 
       - name: Validate lockfile
         if: matrix.language == 'python'


### PR DESCRIPTION
## Problem\n\nWhen CI and CodeQL workflows run concurrently on main, both jobs call  with  and the default cache key. GitHub Actions cache is write-once, so the second job to finish fails to save with:\n\n> Failed to save: Unable to reserve cache with key setup-uv-2-... another job may be creating this cache.\n\n## Fix\n\nAdd distinct  values to each workflow so they use separate cache keys and no longer compete for the same cache entry.\n\n- CI: \n- CodeQL: \n\nThis is the recommended approach in the setup-uv documentation for avoiding cross-workflow cache contention.