### PR TITLE
tooling: add AI guardrails and local safety checks

### DIFF
--- a/.ai-guard
+++ b/.ai-guard
@@ -1,0 +1,38 @@
+# .ai-guard — AI 禁区清单（Novel-Engine）
+
+## 只读（任何情况下不得修改）
+- alembic/versions/*
+- .env*
+- config/env/*
+- data/*.sqlite3
+- data/backups/*
+- .coverage
+- AUDIT_REPORT_Linus.md
+- src/events/outbox.py（待人工审批后删除）
+- src/apps/workers/__init__.py（空占位）
+
+## 修改前必须单独确认
+- pyproject.toml
+- package.json / pnpm-lock.yaml / uv.lock
+- README.md
+- compose.yaml
+- Dockerfile
+- Makefile / justfile
+- .pre-commit-config.yaml
+
+## 编码红线
+- 禁止裸 except Exception
+- 禁止 SQL/FTS5 字符串拼接
+- 禁止删除 raise / assert / validate / sanitize / escape / auth / permission 相关代码
+- 禁止引入新依赖（npm/pip/uv add）
+- 禁止修改测试文件（除非审计明确要求）
+- Python 函数不超过 50 行
+- React 组件不超过 200 行
+- 所有新增 Python 函数必须有类型注解
+
+## 执行约束
+- 一次最多修改 3 个文件
+- 修改前必须运行相关测试并确认通过
+- 修改后必须再次运行测试
+- 优先 surgical fix，禁止重写整个模块
+- 每个 Finding 独立处理，禁止跨 Finding 传递上下文

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,41 @@
+# Project: Novel-Engine
+# AI Guardrails - DO NOT OVERRIDE
+
+## 项目上下文
+- 当前正在接受 Linus 风格审计，审计报告位于 AUDIT_REPORT_Linus.md
+- 技术栈：Python 3.11+ (FastAPI/SQLAlchemy 2.0/Pydantic v2/SQLite/Alembic) + React 18 + Vite + TypeScript
+- 包管理器：uv (Python), pnpm (Node)
+- 架构：Clean Architecture / DDD，分 domain / application / infrastructure / interface 四层
+
+## 绝对禁止
+- 修改 migrations/ 目录下的任何文件
+- 修改 .env* 文件和 secrets 配置
+- 修改 alembic/versions/*、data/*.sqlite3、.coverage
+- 执行 `rm -rf`、`git push -f`、`drop table`
+- 引入新的依赖（npm/pip/uv add），除非获得明确授权
+- 删除 error handling、auth checks、input validation、sanitize、escape 相关代码
+- 修改测试文件（除非审计明确要求）
+
+## 编码规范
+- Python: 函数不超过 50 行，裸 except 必须改为精确异常类型
+- React: 组件不超过 200 行，超过必须拆分
+- SQL/FTS5: 禁止字符串拼接，必须使用参数化查询或严格转义
+- 所有新增 Python 函数必须有类型注解
+- 禁止新增 import-time side effects（模块导入时创建数据库/app 实例）
+
+## 执行约束
+- 修改前必须运行相关测试并确认通过
+- 修改后必须再次运行测试
+- 每次会话最多修改 3 个文件
+- 优先 surgical fix，禁止重写整个模块
+- 每个审计 Finding 独立处理，禁止跨 Finding 传递上下文
+- 修改后必须查看 git diff，确认只改了该改的文件
+
+## 验证命令
+- Python: `uv run pytest -q`, `uv run mypy src`, `uv run ruff check src tests`, `uv run bandit -r src`
+- Frontend: `corepack pnpm --dir frontend lint`, `corepack pnpm --dir frontend type-check`, `corepack pnpm --dir frontend test:unit`
+- Full: `corepack pnpm spec:validate`, `uv run lint-imports`
+
+## 应急
+- 如果改坏了，运行 `just panic` 回滚
+- 如果 AI 开始修改禁区，立即停止并回滚

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           uv run ruff check src tests
           uv run bandit -r src
-          uv run mypy src
+          uv run mypy src tests
           uv run lint-imports
           uv run pytest -q
           uv run python scripts/qa/check_openapi_snapshot.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,18 @@ repos:
 
       - id: mypy-check
         name: mypy type check
-        entry: uv run mypy src
+        entry: uv run mypy src tests
         language: system
         pass_filenames: false
         always_run: true
+        stages: [pre-commit]
+
+      - id: detect-secrets
+        name: detect-secrets scan
+        entry: uvx --from detect-secrets detect-secrets-hook --baseline .secrets.baseline
+        language: system
+        pass_filenames: true
+        files: \.(py|ts|tsx|js|yaml|yml|toml|env|md)$
         stages: [pre-commit]
 
       - id: importlinter-check

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,2927 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".github\\workflows\\ci.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github\\workflows\\ci.yml",
+        "hashed_secret": "92b2bd106b9db9b0ead85afaabca8d4eee67b2df",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github\\workflows\\ci.yml",
+        "hashed_secret": "41c297fbfe1d871ecab95f12884dcbdfbf5980be",
+        "is_verified": false,
+        "line_number": 99
+      }
+    ],
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "681498dd7d31fe1822cc37a559f92d8cff0522e4",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "config\\env\\.env.local.template": [
+      {
+        "type": "GitHub Token",
+        "filename": "config\\env\\.env.local.template",
+        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "pnpm-lock.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "49b650692e9bc09546fd1f3a935da908ca5d02e1",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6307306cd200cc909038e539287d52b9278b4c07",
+        "is_verified": false,
+        "line_number": 112
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f46a8d22e97e7fb677deed4120efefc58359df98",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b46f594dfd11fa8017921fd064b65d8641b85555",
+        "is_verified": false,
+        "line_number": 120
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "df4ed24356e7fc85ece12773e32b1336f9e49221",
+        "is_verified": false,
+        "line_number": 124
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6f54e5f3cff0558a333012cb18a2f7704a4a694f",
+        "is_verified": false,
+        "line_number": 127
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c3056715d6375ab9398baaf6907e8cfea57bcbbb",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6a1911189662b59023c6d2d6d4e1fbc01421b619",
+        "is_verified": false,
+        "line_number": 135
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ed1addc866563fc8c15dbf5f211b2b9a8ed125da",
+        "is_verified": false,
+        "line_number": 139
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "61b438d926a97729d4c06260292d5938f6f496e0",
+        "is_verified": false,
+        "line_number": 144
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "358d94c79d1fe9e2ad5a07f5d690231fec1c79ef",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "af36f44fd661863d2f5bfd56bd67809aa6be8c14",
+        "is_verified": false,
+        "line_number": 152
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e498b588b82623a989bc184233b01bd904b0ffe8",
+        "is_verified": false,
+        "line_number": 156
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d747d1ac07a08d3c197ab6446d08aa3803abb3e0",
+        "is_verified": false,
+        "line_number": 160
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5a47efd79b291e7acbb9652d15614bbc1ff9e36c",
+        "is_verified": false,
+        "line_number": 163
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "be7b197278b2455645ef66b6928113b34fef492b",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e939aafd15ded86a8350eb6bc28ec2cf000896d8",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1fe12c0407c2f932fb13c284c2172e2a3e59ab36",
+        "is_verified": false,
+        "line_number": 172
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7c42e8c70ce385bd67701f657c25b53db12cb140",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e777b15ddeca541bc672c2e2fec5d2d237811d8a",
+        "is_verified": false,
+        "line_number": 178
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6e3546252bc96086749e9cf2097e3f25cbed96f2",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c2a9426a0908ab1def052f1cd9e456c0785bf1be",
+        "is_verified": false,
+        "line_number": 184
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "31ebefcc5752167de22ec7c43082a63174644fde",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "72ad9b29d84be5893947b31eab1b18c6a8708b9c",
+        "is_verified": false,
+        "line_number": 190
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "045fa90493323aefbcb99fc0091ea8cc66634944",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "cd342cb85e3a7974340eb715ca6c988b99fd3c7d",
+        "is_verified": false,
+        "line_number": 201
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "09404efe0c697675f28ac49e2df4736fb4ba6614",
+        "is_verified": false,
+        "line_number": 208
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "15d60609e2958c77b908bf19adc8375b71abee15",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6458cb491193acf3fd23e2431345406d864182a8",
+        "is_verified": false,
+        "line_number": 222
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "88dcf5e48940431d207eb6beeda3f28b52b9dcd6",
+        "is_verified": false,
+        "line_number": 226
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9b1aeb3238bb5411805279e20afb4fb96fa7490d",
+        "is_verified": false,
+        "line_number": 229
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e8cc5935afdfd3788eae945e3db3f42e2c3acee6",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3fe801d380c7196c8da01d8e53ecfaf12fda8d21",
+        "is_verified": false,
+        "line_number": 235
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d3405ba928268e4228a3dccdc89600d0a896c339",
+        "is_verified": false,
+        "line_number": 241
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "98454568854aaca2944151d3c891ee34011636e0",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "928feb1b2bea8361dbcce924d72a1124d6f0e2b3",
+        "is_verified": false,
+        "line_number": 249
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c7cbb342883985169b335ac4e2023d2834266f95",
+        "is_verified": false,
+        "line_number": 253
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "aa48f9f9b67750c27bde00c7ae36d3f4caf324a4",
+        "is_verified": false,
+        "line_number": 257
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2019dc75677f3ab499f7ceae541bb0b59cf81546",
+        "is_verified": false,
+        "line_number": 261
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0cdcfb21bfb1bf4ecb8552f8c353c88e68a4e6bd",
+        "is_verified": false,
+        "line_number": 265
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "938e1664eafa2ffe5ef25635c1ee5aa279ddc9f7",
+        "is_verified": false,
+        "line_number": 269
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "48526743fc9cc20ee0d650606e546b97383ba06c",
+        "is_verified": false,
+        "line_number": 273
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a557c81920e64db2b049517b488253710f40ea21",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e79d02e415669376b9f3e0739277744d1ad13205",
+        "is_verified": false,
+        "line_number": 287
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "70e0115878cbcfa3933ef674125fe6edc40b1ddd",
+        "is_verified": false,
+        "line_number": 290
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6158060fd3a28e3bdf7b7e37bcc8c8f3348147f0",
+        "is_verified": false,
+        "line_number": 294
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b18a51ff2b05238234261f264ee4810ddb31a3ab",
+        "is_verified": false,
+        "line_number": 298
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d2162ede46b32d726584142e374458026c95c209",
+        "is_verified": false,
+        "line_number": 302
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7252305e0579e7dd1ebf234edb891484f3ac7a71",
+        "is_verified": false,
+        "line_number": 306
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b19f96aa1c47675e855a3bad8bb2687dfadf9f4c",
+        "is_verified": false,
+        "line_number": 310
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a570549460eafd1f7f63656926cec0ce21ab4513",
+        "is_verified": false,
+        "line_number": 314
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4aabf445183f5187e042e6b54d5171426e5df8b7",
+        "is_verified": false,
+        "line_number": 323
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "be0ebc25d6f5b6ad9c0c67104e56bbeb2b46373a",
+        "is_verified": false,
+        "line_number": 332
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "83fb085b98cb3377c7ec6a9d6e8f8745e6de4de1",
+        "is_verified": false,
+        "line_number": 341
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "693a58d8eb9d67f9d0b4d5eccac282a38128a824",
+        "is_verified": false,
+        "line_number": 350
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "da5e229c42f19b8113fbfad7a97dc10d72a0f43f",
+        "is_verified": false,
+        "line_number": 359
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "eac36d9e961bc65230662c5b61b8cd6ca70c4bf6",
+        "is_verified": false,
+        "line_number": 368
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4d8ce30f06f10a162a0935c66726a6d38608ace8",
+        "is_verified": false,
+        "line_number": 372
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b37a03ec6dc2d374c82d1bd262d4c31e1a822eef",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1ad10cb47fe0f85b6170b42acca5228857ca1cba",
+        "is_verified": false,
+        "line_number": 390
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f72cf845673098bb8b01037dbb5b567e498bc864",
+        "is_verified": false,
+        "line_number": 399
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ecc2bb9da6d7d9f8b3f5ed822c7d310b8cc5a152",
+        "is_verified": false,
+        "line_number": 408
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2688416b12ad5126c832d9ab2bfbaaef0a09d370",
+        "is_verified": false,
+        "line_number": 417
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0fcf89a0622c77972aae8b02a3e48772bb8d6bfa",
+        "is_verified": false,
+        "line_number": 426
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a85a810fee555604c14cccc9fe1c01aea02b7881",
+        "is_verified": false,
+        "line_number": 435
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8733ba82d33885a92ca3009eb6ba61e505a1ee9a",
+        "is_verified": false,
+        "line_number": 444
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9d1b9dbec9f048e048f4dd38591947ca7deff5dd",
+        "is_verified": false,
+        "line_number": 447
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "56f2c933b7afa8e13bf7c81e684d7adfdc945431",
+        "is_verified": false,
+        "line_number": 451
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
+        "is_verified": false,
+        "line_number": 454
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b0e9cbf320ebe74507bcdaae3f0b40740459a092",
+        "is_verified": false,
+        "line_number": 457
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c835bab9a1ef9d19a96e51b6938acbdf2c07935d",
+        "is_verified": false,
+        "line_number": 460
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "95c387067b1d1908e41fccb4d3b5c109fbc9c6e1",
+        "is_verified": false,
+        "line_number": 463
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "46958502df33ab3b26cf00df47073c6c047b6cdf",
+        "is_verified": false,
+        "line_number": 466
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2c67a27fa817cee77e3bc107c31e2bdfa883c221",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f0cf8ea8e416f64e872d50a8e070f789f8673488",
+        "is_verified": false,
+        "line_number": 472
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f484c03aca35465e81a73fb662fc4e78b4a16705",
+        "is_verified": false,
+        "line_number": 475
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c9066c2a926259110f81d7397246ded154e328af",
+        "is_verified": false,
+        "line_number": 478
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a87c2c93a8ca64acdce94a66ff000a8b96933062",
+        "is_verified": false,
+        "line_number": 481
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8b4b319e9117c68fe42379e5a860d7ff7b0495f6",
+        "is_verified": false,
+        "line_number": 484
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9a1373fb8bc6343a2626079c5c977463daea3541",
+        "is_verified": false,
+        "line_number": 490
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e768776e74a3cb5645d538a9bd074c78e7fb52b3",
+        "is_verified": false,
+        "line_number": 494
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "150a1608ffd7395d510860bc11f1b69b49ff015a",
+        "is_verified": false,
+        "line_number": 498
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a40b5bfa2293503ab38836ff9536bb483b6fae9d",
+        "is_verified": false,
+        "line_number": 502
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b5b6d48460f3ce7c0ee71c156fa178805b4b632c",
+        "is_verified": false,
+        "line_number": 505
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "cf5f1f76557d4d4e4baa1acb2c472ca8cb776b95",
+        "is_verified": false,
+        "line_number": 510
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "02c88c1a524c48720e82d48fd6a1e85a09e7d4e2",
+        "is_verified": false,
+        "line_number": 513
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7fa5f4dace93a59cb7c7331612e79939d0d2d008",
+        "is_verified": false,
+        "line_number": 516
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b5f2212097204e1bbaaa6a1bcc9adbeaaf9f8f13",
+        "is_verified": false,
+        "line_number": 520
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "cc380ead6bf1f7503a9bbd138aa3e3ca8f50f18d",
+        "is_verified": false,
+        "line_number": 526
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2b7740c436dac04cd62e5b7ab2b1ea723775efba",
+        "is_verified": false,
+        "line_number": 532
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "02b363707319fdfadcea88eb9b972b1d9e948efc",
+        "is_verified": false,
+        "line_number": 538
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f0374662134e46b04afb522d16e7aac8cb6602fe",
+        "is_verified": false,
+        "line_number": 544
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "57f55bb9fe5be52dda98f80434419695d45525e5",
+        "is_verified": false,
+        "line_number": 550
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7ca89062a54dbcab4ce27dfb747bd42e31f82036",
+        "is_verified": false,
+        "line_number": 557
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "90096b76cf7576044e015facaaa7f9c8e31edc4a",
+        "is_verified": false,
+        "line_number": 564
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "18bd7a826721fc29a48d733db1b72ee32b294402",
+        "is_verified": false,
+        "line_number": 571
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6c8a0acefd44286c618662fbe0f74d63c54179b3",
+        "is_verified": false,
+        "line_number": 578
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "976ff6ce6ac1cbe8f59ac5b42845da926553894d",
+        "is_verified": false,
+        "line_number": 585
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4913ea25e3e4b32e5281c48a57c054ded3746a74",
+        "is_verified": false,
+        "line_number": 592
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6c0dca1b0bc44938c474b1402c1e636d52aceec4",
+        "is_verified": false,
+        "line_number": 598
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "24eb7e248bb827da59fb6bd675dc8a3be11c66e2",
+        "is_verified": false,
+        "line_number": 603
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c3a25814f4363a237eebfe21f22778077b83ffad",
+        "is_verified": false,
+        "line_number": 609
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b0da61692236cf0f51dfca9bea5b058e6db2a173",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1e9ff9fee5ad181d3f63618e0267e8ad42826e83",
+        "is_verified": false,
+        "line_number": 618
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e0cad2c1c2babcee39a4c25ea773656432e980b5",
+        "is_verified": false,
+        "line_number": 621
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4f30f4179bf6aad2e2db264609aca318cddd0299",
+        "is_verified": false,
+        "line_number": 625
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2a99232e74af9898db82959893e9c64814b15714",
+        "is_verified": false,
+        "line_number": 629
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "23b847f3370f612113c53bca00cffae8e46fb58b",
+        "is_verified": false,
+        "line_number": 632
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7739c7a36e8b5c9759887d54c3d3a252d017cb71",
+        "is_verified": false,
+        "line_number": 635
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d4dda0583372eb865e22ea00ae160ceb315aa0df",
+        "is_verified": false,
+        "line_number": 638
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "fa52615bd39e56c7366b834e0c9b496bbb96f043",
+        "is_verified": false,
+        "line_number": 641
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "545a34d82a69ee367dc06267bd30705fc686e387",
+        "is_verified": false,
+        "line_number": 644
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "07094b00e1d6e8dec64084898b7bed8a5992a857",
+        "is_verified": false,
+        "line_number": 647
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9402ea0418d951032aaabe0acfd5aff1da20095c",
+        "is_verified": false,
+        "line_number": 650
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d0927576ff5b588bb9c6406e694a036922d92093",
+        "is_verified": false,
+        "line_number": 653
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6cf728b4ed8aa6671dc6ae7520890a09015524d8",
+        "is_verified": false,
+        "line_number": 658
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "969f107ddf8ddeaba42e3768b1d0451c2777eee0",
+        "is_verified": false,
+        "line_number": 661
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1c08c7e98f6c3ad27dec81366b66f6a96c5fe26c",
+        "is_verified": false,
+        "line_number": 669
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e1429150ed1defcbfad5c4c571aa0b0956d76363",
+        "is_verified": false,
+        "line_number": 676
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0925f06c83cfd4c4c1fbbbd04ad8635b1974d31f",
+        "is_verified": false,
+        "line_number": 682
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "45b047d69c3101243005e5737df715c314f5eae7",
+        "is_verified": false,
+        "line_number": 686
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "28780489aa88dca544f8dea959bc7219ee3fd6fd",
+        "is_verified": false,
+        "line_number": 692
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "41a33a93984b14046afb9de7cc4f4185883149aa",
+        "is_verified": false,
+        "line_number": 699
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f6dd1859015eca5ca7dfcbee198b5a55f1cee710",
+        "is_verified": false,
+        "line_number": 703
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1308826ac9abe15414b6b6f45e83280263194f22",
+        "is_verified": false,
+        "line_number": 709
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8a253f132b08e7c4d2cbac7e98e41ac3d182c4a7",
+        "is_verified": false,
+        "line_number": 716
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9deb153cbb522915b92e147a19baa3e36c6b2635",
+        "is_verified": false,
+        "line_number": 720
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d2368b69bea2c82b5cc8bdd19e11d2d98985d07c",
+        "is_verified": false,
+        "line_number": 733
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "aeea04934edf137499a9f18d68c8f2626e2794e4",
+        "is_verified": false,
+        "line_number": 742
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "223048508f0d737013d49bf59e3968ac299b8a99",
+        "is_verified": false,
+        "line_number": 745
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e9bf04220456ddd9f7e8b92be81d882ba206ef2b",
+        "is_verified": false,
+        "line_number": 756
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "11c2a60c63d4dbb71e847c5e9b2a5d0725aad931",
+        "is_verified": false,
+        "line_number": 759
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0c5cebcce1962476bddc9e0f9396b44ef06fa138",
+        "is_verified": false,
+        "line_number": 762
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "00a18f0555ea372c6aa4925456238af253552b77",
+        "is_verified": false,
+        "line_number": 765
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "98ff88250b0b0018e25e9d3e37a3852065ba8ad8",
+        "is_verified": false,
+        "line_number": 768
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2f582518a7d025e7efbc4ef2cf8cc5cf9487b200",
+        "is_verified": false,
+        "line_number": 771
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b2c03df0ed8f8caded3abab58c3b2e3b645dbb28",
+        "is_verified": false,
+        "line_number": 776
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f2d08166d55f8cb2912054fc3b1243f2255fac48",
+        "is_verified": false,
+        "line_number": 781
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "35ca90e5fa9b87427a5ff8b3f333a7b7d45fc260",
+        "is_verified": false,
+        "line_number": 784
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8dbe57e0fb77e02e3c6ce2fea324da52988cc557",
+        "is_verified": false,
+        "line_number": 788
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d15b82853a984c45aab87399878c98082bac85ba",
+        "is_verified": false,
+        "line_number": 792
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "371ce323d657e273939fdad274085642a4da69de",
+        "is_verified": false,
+        "line_number": 796
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "22bd0abeadedbe4ac89a1415cff3788f50a4dc48",
+        "is_verified": false,
+        "line_number": 800
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d032728a18c71c0a8e3f18b060f12d1ab9755c47",
+        "is_verified": false,
+        "line_number": 803
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b8434babdebe87a28a32c342a9ed215e5fe43378",
+        "is_verified": false,
+        "line_number": 806
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1c504c77e2b9f1ea0e1770e65673fd7f8b3f4c8f",
+        "is_verified": false,
+        "line_number": 810
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4f11ee0328cf250026fb8282b51127bc264b06f3",
+        "is_verified": false,
+        "line_number": 814
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5b7cd7946ca5e56496386ea38016606310bfcf03",
+        "is_verified": false,
+        "line_number": 817
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e0ed71a4c2836a6a251bef5e00b00401cfac286d",
+        "is_verified": false,
+        "line_number": 820
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0445deb44be67d9973df3ad6d4d78bca844eaa83",
+        "is_verified": false,
+        "line_number": 824
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "47247a7452b7c24a2e4e36ceeba1dabeb178028a",
+        "is_verified": false,
+        "line_number": 827
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f3ce430d4c1e91228db9002ad1d3ef9a4847a568",
+        "is_verified": false,
+        "line_number": 830
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4cd454d960136b7b4f74cca3c12010ff2ebd7663",
+        "is_verified": false,
+        "line_number": 834
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "38119d6755480fd81caed75382e6bcbb3685ca44",
+        "is_verified": false,
+        "line_number": 838
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7e0c8e7bebd3b26c7a99961ec3498c0448dcb08d",
+        "is_verified": false,
+        "line_number": 841
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bc23715592b7602434c2776230d19f43fc479898",
+        "is_verified": false,
+        "line_number": 845
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5e5e944819f9ed1defbf3b9cf387214fb2f04d61",
+        "is_verified": false,
+        "line_number": 849
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2ee2ba1ba92b35b86efce34680dd6e1300084026",
+        "is_verified": false,
+        "line_number": 853
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0f90805c54ad05a4afefad936aa0687535f1b8c1",
+        "is_verified": false,
+        "line_number": 857
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0fa396e95b690119dc2b12237947c5443bdbb9d7",
+        "is_verified": false,
+        "line_number": 860
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a585dd20494231e2502065aad0f87fae36c9a6a2",
+        "is_verified": false,
+        "line_number": 864
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "690af56af1384793272c233c11ffb5d354b49fc0",
+        "is_verified": false,
+        "line_number": 868
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4ed49acfbd180533265d2099f3043963c4a24443",
+        "is_verified": false,
+        "line_number": 872
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "428e72f71455a785963f1df5f85c26c6d6ae519b",
+        "is_verified": false,
+        "line_number": 876
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "951e0374c9a1d7fa0e1428f26e825abcc92681e0",
+        "is_verified": false,
+        "line_number": 879
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "df911743057e957d166c09e0746e85bf596195d6",
+        "is_verified": false,
+        "line_number": 883
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "98da97093cff2b0693b2f8ccc5b7e74758ae9f3e",
+        "is_verified": false,
+        "line_number": 886
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "08c8ee0987f57add8cd4071488caef8ec431336a",
+        "is_verified": false,
+        "line_number": 889
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "19a6624850250a02e49723a62e0348444869970f",
+        "is_verified": false,
+        "line_number": 892
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "862951cd71d0412b5e52bae3e952725486a655b0",
+        "is_verified": false,
+        "line_number": 895
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3752b70c2c4391586cfb164832e45682b1ecfc22",
+        "is_verified": false,
+        "line_number": 899
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bf2a7aa50ec6063cbb616daadb50eec0213fa61f",
+        "is_verified": false,
+        "line_number": 903
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a35cbc541c025ba5ccef5ca780a743f94848a218",
+        "is_verified": false,
+        "line_number": 906
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1259773a720ff6c462f3fff70a0881f503563c9e",
+        "is_verified": false,
+        "line_number": 909
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
+        "is_verified": false,
+        "line_number": 913
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "cf3e48f5af3fca6bb9135acdee135247bcae1307",
+        "is_verified": false,
+        "line_number": 922
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b0f6a9f09dd8a0ebc50e6d4a7a81e126cd64ac6a",
+        "is_verified": false,
+        "line_number": 925
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d031e18cc14e54a719197084af4cd6b2372fd005",
+        "is_verified": false,
+        "line_number": 928
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bef68af5091abf3bd912b28fd2f8b438426dd79d",
+        "is_verified": false,
+        "line_number": 932
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c02b39bafb6389010b678e8a4714d2ddfb10fe59",
+        "is_verified": false,
+        "line_number": 936
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "46a4e83f9f3f3670ec1cf4445789431038008dc2",
+        "is_verified": false,
+        "line_number": 939
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bedb2ecaf027607fac6d4c72d9b81bad23396285",
+        "is_verified": false,
+        "line_number": 942
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "fc7b2f07f919c3f8e20aa78a1756d2bcca252fb9",
+        "is_verified": false,
+        "line_number": 945
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4dbd764aef0abb1805f47f0a24fecf90f95da0d9",
+        "is_verified": false,
+        "line_number": 948
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d3bc9e85ef73bc81be3c9767f7c26c7600f357c0",
+        "is_verified": false,
+        "line_number": 952
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6c88ecf20f9dc070ee18f0cf59f58b0025f6ec55",
+        "is_verified": false,
+        "line_number": 955
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ee9d1b64a3dfe95f432a67bb816895c3203aa972",
+        "is_verified": false,
+        "line_number": 959
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e8a5f750f33ead31e9d8e65ba5cb63152288710d",
+        "is_verified": false,
+        "line_number": 965
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f356716cf94345569637c97e678030c8785cfbaa",
+        "is_verified": false,
+        "line_number": 970
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2a5c1a897332b7652d1daeb248e27b29123ca884",
+        "is_verified": false,
+        "line_number": 974
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7bf692c49036f6e8ac29f859913d8b5ad4ed34bb",
+        "is_verified": false,
+        "line_number": 978
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "99e3e5f5d9f570cf4d4af4bc1c43544b0b2392ef",
+        "is_verified": false,
+        "line_number": 982
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f6c70988c4d62136a4e62cd98c86fd9388224e66",
+        "is_verified": false,
+        "line_number": 986
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "40d5009f0315cf3dab4a4d129f8e556b6838d879",
+        "is_verified": false,
+        "line_number": 996
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c8566f6301c749c574462db3cef2c1f3a10a03c0",
+        "is_verified": false,
+        "line_number": 1000
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "51e9263c74493cd77c2d25adb255b15647d84512",
+        "is_verified": false,
+        "line_number": 1004
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1790c1f42e3416e31561c46b258d2f69c1608c85",
+        "is_verified": false,
+        "line_number": 1008
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
+        "is_verified": false,
+        "line_number": 1012
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2fcbf434b04ba0a49ae29f1d9ea0edc30881350b",
+        "is_verified": false,
+        "line_number": 1015
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "16d0c877fca994fd1c43bd7f131be967bf4f87b6",
+        "is_verified": false,
+        "line_number": 1019
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c0f64a532897bbd5497996fdfec7cfcd087540ce",
+        "is_verified": false,
+        "line_number": 1023
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b58ece1a23c6b414412378abceafd8549e609789",
+        "is_verified": false,
+        "line_number": 1026
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "fea0d9c5b0c53c41e6a0a961a49cccc170847120",
+        "is_verified": false,
+        "line_number": 1030
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "283a181bd9971789ceaee59c32a0f93e31a7a2a8",
+        "is_verified": false,
+        "line_number": 1033
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "02031683c4d321f8660ff8b2d0258362940c8a6d",
+        "is_verified": false,
+        "line_number": 1036
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
+        "is_verified": false,
+        "line_number": 1039
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c5b9224d6550ddd6a9d3e700fd0a58360b11ca0d",
+        "is_verified": false,
+        "line_number": 1048
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7c235e480345a8563b9b7348d8b568bd51bf3814",
+        "is_verified": false,
+        "line_number": 1052
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3594781b38f5d70bb1b747317347cf06b2a0cc01",
+        "is_verified": false,
+        "line_number": 1056
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "76332214739a4c7dd7c65873aa473b0b918d47e4",
+        "is_verified": false,
+        "line_number": 1060
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6469b5be81ddc9f74fdb35bb646526db702e0f3d",
+        "is_verified": false,
+        "line_number": 1064
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9c422f6dfca5f8acb3d3923f7aed45865b8e1168",
+        "is_verified": false,
+        "line_number": 1067
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
+        "is_verified": false,
+        "line_number": 1072
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a848de44c6988252a196abf85c9284ffcb16e972",
+        "is_verified": false,
+        "line_number": 1077
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "371ca38e7acde2cb9e7c1a8bea0355722ff047cf",
+        "is_verified": false,
+        "line_number": 1081
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "89345a033a4ecac54d56210d7fb9533fddc58490",
+        "is_verified": false,
+        "line_number": 1085
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "043f592ee4062fbb234261a5cb68546115ae8485",
+        "is_verified": false,
+        "line_number": 1089
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4d0e714a0f6a740c6b6b047cf9b513bf8ff4c898",
+        "is_verified": false,
+        "line_number": 1093
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "086b47ff4b09d5daf48fc11a12842df114051a64",
+        "is_verified": false,
+        "line_number": 1097
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0d96d45dd8e09cb4633cd3318f47162fc2257667",
+        "is_verified": false,
+        "line_number": 1101
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bbc5944e53f4bc00cb7c83d4ffdf2f3e477e2ee5",
+        "is_verified": false,
+        "line_number": 1105
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "36069c197c7fe3da77596e97d3317b501a686ce3",
+        "is_verified": false,
+        "line_number": 1108
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c6ee5cc9425c6e106fad752bf1f79925d0f8d332",
+        "is_verified": false,
+        "line_number": 1112
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f09b00d00e74c891c9bbc0614a19d47015e616c1",
+        "is_verified": false,
+        "line_number": 1116
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f1ac10cceb66eae06a957162ed1c39f18f017ee5",
+        "is_verified": false,
+        "line_number": 1120
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e25be230742364f1ee60067a756da19dc7572126",
+        "is_verified": false,
+        "line_number": 1124
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1109544447e298af75035b2bbfc851610f963a65",
+        "is_verified": false,
+        "line_number": 1128
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e9ce08fb0922eb7b6fd8078a79f948726b9b756e",
+        "is_verified": false,
+        "line_number": 1132
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d5ec021cbb92c3486e38fac176f4f59a6c1d92e8",
+        "is_verified": false,
+        "line_number": 1136
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0168f03d6f1748d5d7ae624a93f711333b69d01c",
+        "is_verified": false,
+        "line_number": 1140
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2f1b0d290a74f226e457d82589deb547e44b0b00",
+        "is_verified": false,
+        "line_number": 1144
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8f95bdf43361cffe6720264f402b5636239f6367",
+        "is_verified": false,
+        "line_number": 1148
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e907e408e8ac716a2dc03c3a56283b57e5bb5c73",
+        "is_verified": false,
+        "line_number": 1152
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0133f717e382463ee4cf5742898fd65cd86dcdce",
+        "is_verified": false,
+        "line_number": 1155
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "72fe81b664ff3e8f2cfd463e4ce38ef94e2ba274",
+        "is_verified": false,
+        "line_number": 1159
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4e5e279b264f80f6302507f3bc02028118a5381f",
+        "is_verified": false,
+        "line_number": 1163
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e53d61332d1bf1be17d33eb4955ecd7fbed6bf02",
+        "is_verified": false,
+        "line_number": 1166
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4dfc67bc966e2494008a5f5e346fca119afccb91",
+        "is_verified": false,
+        "line_number": 1170
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1633ee6a9a0c91bca3ca3691bc73488dab661b3a",
+        "is_verified": false,
+        "line_number": 1174
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d4ab4bf7e2f51f73ffcc91ab533b0ceb1cd1a778",
+        "is_verified": false,
+        "line_number": 1178
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f81d0bc25dc2fe42f34d5a3230fa522b16c245bb",
+        "is_verified": false,
+        "line_number": 1182
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
+        "is_verified": false,
+        "line_number": 1185
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6f6b67f135fc55ac5cb87089c812e6a75596b23f",
+        "is_verified": false,
+        "line_number": 1188
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "72e598c7923f1fce1137d72e26f9c6bcb1659f3c",
+        "is_verified": false,
+        "line_number": 1192
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "32f166e925f96dafcba74b3787246df2a06a9e19",
+        "is_verified": false,
+        "line_number": 1201
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "127f92724797904fb4e6de2dfff2c71c07739612",
+        "is_verified": false,
+        "line_number": 1204
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "518c6e09c048b1b3cdbcc4ed47df84e0552aba4c",
+        "is_verified": false,
+        "line_number": 1207
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4c565e2b5132b7df2d3126654bee51cf449f5d8f",
+        "is_verified": false,
+        "line_number": 1210
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0ec89f07004a01dda54b29e48a86c84f8098fdb6",
+        "is_verified": false,
+        "line_number": 1213
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ecca8c8ee1920fbd6387220767bdecf3635a3741",
+        "is_verified": false,
+        "line_number": 1217
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b48b7cde42a2442c78c359b776b516d8127006c6",
+        "is_verified": false,
+        "line_number": 1223
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2fb4be4f309d24f5064ac5496b8c7f59df0bf966",
+        "is_verified": false,
+        "line_number": 1229
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b6acf38d09475b54b197ff0574abc4a7e86c3543",
+        "is_verified": false,
+        "line_number": 1235
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "405ac79c3832190ec6bd61bce50e9390a026af72",
+        "is_verified": false,
+        "line_number": 1241
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5f3d1367a38ac4e76290f44b6dc26d3555bbabf5",
+        "is_verified": false,
+        "line_number": 1247
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d86912fe91c497e31a4344f459a68586ce096966",
+        "is_verified": false,
+        "line_number": 1254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1509ab36ebf61526ec42f40016db32b0925e96bc",
+        "is_verified": false,
+        "line_number": 1261
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2139b734b30d5642cf104ea814b455bf3f08ca4c",
+        "is_verified": false,
+        "line_number": 1268
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ef73b9a0b786d2e003921cc9967a0a7cd6ae1913",
+        "is_verified": false,
+        "line_number": 1275
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2ffc317e2ecc11d98e3e05bf565c6575c4cbfd51",
+        "is_verified": false,
+        "line_number": 1281
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "432730c731e24c084f98525d5e133e358dc47b2f",
+        "is_verified": false,
+        "line_number": 1287
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1c386996454f57fad765143b1a1393b4fd15dceb",
+        "is_verified": false,
+        "line_number": 1291
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f30db3965cfaf45c216038e7ce454d23be9c08b4",
+        "is_verified": false,
+        "line_number": 1295
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "41ad6b05048218fa309a2f439b527298ce252c12",
+        "is_verified": false,
+        "line_number": 1298
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
+        "is_verified": false,
+        "line_number": 1302
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "63d30aed59bb73a9e15ad6f56031fb19340007ba",
+        "is_verified": false,
+        "line_number": 1306
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "558e9e100ed7994869c606cd7d02e0cb43307d4a",
+        "is_verified": false,
+        "line_number": 1310
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7aa924d4aef9f14c78acee8a31bcbd78b26e9898",
+        "is_verified": false,
+        "line_number": 1315
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1e2228f0d8e0fc2bc3b8740a8ff3d287006b9a38",
+        "is_verified": false,
+        "line_number": 1319
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "14f0cf051cda99c5fcabae9de146dc55193c9f4d",
+        "is_verified": false,
+        "line_number": 1322
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bed2be7dcefaad482d5b1215bb9c485bc1904f76",
+        "is_verified": false,
+        "line_number": 1325
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8e193ad7099ffd82fbb600c11c8e057de00db18a",
+        "is_verified": false,
+        "line_number": 1329
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "73f99321c1d31c19b059d58bf503320edb5ca0b8",
+        "is_verified": false,
+        "line_number": 1332
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "81a165cc6dfc1c5b2a498fefdd6a0774232063b9",
+        "is_verified": false,
+        "line_number": 1336
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "abb99044ff3c205878969cf6238197f65ebb1193",
+        "is_verified": false,
+        "line_number": 1340
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "06c654850ce93559d42fd5f657cbee6c4d9b47c5",
+        "is_verified": false,
+        "line_number": 1344
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "31d6671bbf40210dfde8e313a9c03ab41489691d",
+        "is_verified": false,
+        "line_number": 1348
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "daf34481e73c91f0888018c377e845f49be248bc",
+        "is_verified": false,
+        "line_number": 1352
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
+        "is_verified": false,
+        "line_number": 1355
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "84aa7d25b60745899c3d0ba6d1f9c6ad0808e39a",
+        "is_verified": false,
+        "line_number": 1358
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5b6b494f771ff69c35ad46e17ec1f7da6eb8696e",
+        "is_verified": false,
+        "line_number": 1362
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "508ffd78a7522f83c630d98474d58ccf406bd25e",
+        "is_verified": false,
+        "line_number": 1367
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a56ba07ec056b3f2abf7f6b6da7758f073a3b6db",
+        "is_verified": false,
+        "line_number": 1370
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f919cefce72278c96d5c9618afcd94552f6e6721",
+        "is_verified": false,
+        "line_number": 1374
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b5a6f2a2101ff7f7af8d0c6c87c554acea27e0c9",
+        "is_verified": false,
+        "line_number": 1378
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "efd5297b2538146982d7976a0fde2d26b76ec25f",
+        "is_verified": false,
+        "line_number": 1382
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d69c03a6c481565a321e7b90776918eaad16e532",
+        "is_verified": false,
+        "line_number": 1386
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "316bf5ed09ed2d2511c54a3e60e047e26550c82c",
+        "is_verified": false,
+        "line_number": 1390
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "139323d71483de0860981200fb39673681ab2ef2",
+        "is_verified": false,
+        "line_number": 1394
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f90f85b184e7d9bf4f0cb27955a9062675a414a5",
+        "is_verified": false,
+        "line_number": 1398
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "533573708ed3eabce514432cd26d532218222659",
+        "is_verified": false,
+        "line_number": 1401
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "61ff5c8a702d8ffe28063c06487a3a5a0db2ed70",
+        "is_verified": false,
+        "line_number": 1405
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
+        "is_verified": false,
+        "line_number": 1409
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
+        "is_verified": false,
+        "line_number": 1412
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3bae03646f3110a32c0d619e0c5fb4a15d624dfb",
+        "is_verified": false,
+        "line_number": 1415
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "84cbfec871cf2b178ab90fcc1f442fa369e99a02",
+        "is_verified": false,
+        "line_number": 1419
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9dd8b7bcb847f86a200200adcb41ae1230319c9a",
+        "is_verified": false,
+        "line_number": 1423
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ba8a4a4ea1707cd9c5a04000ad2a40c0890c22c6",
+        "is_verified": false,
+        "line_number": 1428
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d2dd9ebda8816cd5b1410beaed68e727087e0005",
+        "is_verified": false,
+        "line_number": 1433
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a9f4471f97e04ad3f10a2014bee29f4c89a64690",
+        "is_verified": false,
+        "line_number": 1437
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "740c72e48345f65f0deefba812581017bd57c614",
+        "is_verified": false,
+        "line_number": 1446
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2f626a07077750dcc13a5c8ca57c713870453ea2",
+        "is_verified": false,
+        "line_number": 1450
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "21ce40fa7b942491db7f5babb19538e726c27e8d",
+        "is_verified": false,
+        "line_number": 1455
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "706884687450108cef742ef7b12010f29167a501",
+        "is_verified": false,
+        "line_number": 1459
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6c8698ec180cb58d9c2baa683e3a57c1eb18e2f3",
+        "is_verified": false,
+        "line_number": 1463
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "62066f5078abd3f1c707b12b69fcb8d5c45f69ff",
+        "is_verified": false,
+        "line_number": 1466
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ef92e3e90926767f04ea05b4fc58e71019cf68d5",
+        "is_verified": false,
+        "line_number": 1471
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5a59ca4fb733a2faba503be8098a6bc578a09415",
+        "is_verified": false,
+        "line_number": 1474
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "0ef086d3cbd10e1507e6a12b304b7c5c601874de",
+        "is_verified": false,
+        "line_number": 1481
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4f171d08ea6de5b94bad0eff32e65a96a10ac15a",
+        "is_verified": false,
+        "line_number": 1487
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8eb603f181d16409922883159c02899b089f6d60",
+        "is_verified": false,
+        "line_number": 1491
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5a485a4915f94231f9dc5b355ddda367442ba450",
+        "is_verified": false,
+        "line_number": 1495
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "41135cd24fce09855f67710faed09efce38cd9fb",
+        "is_verified": false,
+        "line_number": 1499
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bfb59a5ae276713612fc79718254aab71db0463d",
+        "is_verified": false,
+        "line_number": 1503
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "19a998b1bf7031d19515cd35f049a7a6aa7dd1b3",
+        "is_verified": false,
+        "line_number": 1507
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3c223276ccd44f1ac8cd7ed64e7f48ddc71ffea1",
+        "is_verified": false,
+        "line_number": 1511
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "dba7a636ef0b7f00cb8c1cfce617db1201444012",
+        "is_verified": false,
+        "line_number": 1516
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
+        "is_verified": false,
+        "line_number": 1519
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "6c8d2de91b8087bf6f18c9b505ec528e2bafb7c4",
+        "is_verified": false,
+        "line_number": 1522
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2e9e26d0fd5a69fc56b781ec5b24890dfb4976fe",
+        "is_verified": false,
+        "line_number": 1526
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a5904e638a92a51c5b14cce419c5a4bcbb63f587",
+        "is_verified": false,
+        "line_number": 1529
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3b7990b0f82bc9bc6c4ec02744f9c02e76aac827",
+        "is_verified": false,
+        "line_number": 1534
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9072ebcbad57a1ae4256c5ae37c1e7c7ae5325de",
+        "is_verified": false,
+        "line_number": 1538
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
+        "is_verified": false,
+        "line_number": 1542
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e0c6ae09dd70fa25056d591ada0ad32df0dfe873",
+        "is_verified": false,
+        "line_number": 1545
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
+        "is_verified": false,
+        "line_number": 1549
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c44c74adebc4e9832e4ef9dacc60f36520f7e919",
+        "is_verified": false,
+        "line_number": 1553
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8db956011899a12e5f3cd3b6451ca77c5896f94d",
+        "is_verified": false,
+        "line_number": 1556
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
+        "is_verified": false,
+        "line_number": 1560
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c8fac131170b7bd907b0771e52111a64e940b2a5",
+        "is_verified": false,
+        "line_number": 1563
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "198b95e95ae789d73b7ad4c7acd81e6d9a9638a4",
+        "is_verified": false,
+        "line_number": 1566
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bdaf8b094715fef6fc9d26c411bc0f51e1f4d6bd",
+        "is_verified": false,
+        "line_number": 1570
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "b1c179f98a45a16ae541474f4a1b00bfd13ea1cc",
+        "is_verified": false,
+        "line_number": 1574
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "4c8a960439864672cef22edf28a40c8a3749ed68",
+        "is_verified": false,
+        "line_number": 1578
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "7268ef4cac1850afd5fa09179f14b9ba7945e998",
+        "is_verified": false,
+        "line_number": 1582
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bd781c148f26d1f4846c44ad3eb29636a326b436",
+        "is_verified": false,
+        "line_number": 1586
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3e536139add3f70bf34712d57cf490dc9c631553",
+        "is_verified": false,
+        "line_number": 1590
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a434b9fdf5a0289de9b8ec24d32472bef6f23e19",
+        "is_verified": false,
+        "line_number": 1594
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "69e4418b2ffb487c86b50465bb7a8dd539577c3f",
+        "is_verified": false,
+        "line_number": 1597
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "eeacdd78906304066ade634711edfa3120b26515",
+        "is_verified": false,
+        "line_number": 1601
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f66e3c03e79ebf35d762ff54c0ddfe45d014462d",
+        "is_verified": false,
+        "line_number": 1604
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
+        "is_verified": false,
+        "line_number": 1609
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "c8401648a1024646ca951addc1693d4600512ccc",
+        "is_verified": false,
+        "line_number": 1612
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d6233dd65dfcbe4d7aaae3262255027e3185f41a",
+        "is_verified": false,
+        "line_number": 1616
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f0661775df2ce05e6c49ee07d6003c0e831cda30",
+        "is_verified": false,
+        "line_number": 1620
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "2ba5370328fa1b3dc1246307e508a5c6fc8f35fb",
+        "is_verified": false,
+        "line_number": 1624
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "ba59b281beb872a8bc78b586fb1cef602f3eb373",
+        "is_verified": false,
+        "line_number": 1627
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "36a41bfa336a40f390233bcb3edba75b423c0ac5",
+        "is_verified": false,
+        "line_number": 1631
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bf3e3cda4d110e6f625eae7b1bc8bd5d9e1cd8d5",
+        "is_verified": false,
+        "line_number": 1635
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d285b26b3ab9fd0767eb725dd5607b8dda63cf6f",
+        "is_verified": false,
+        "line_number": 1639
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "019caa87257397d1720cb9ea2634186b43d47704",
+        "is_verified": false,
+        "line_number": 1643
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
+        "is_verified": false,
+        "line_number": 1649
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a09ac4be578a7b177bc5f823f8624e32f10751fb",
+        "is_verified": false,
+        "line_number": 1652
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "8239574b4263502316ae4af75858c8537b8f9dc2",
+        "is_verified": false,
+        "line_number": 1656
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "3894350d13957352daa8660e7b56bf06e05e494c",
+        "is_verified": false,
+        "line_number": 1661
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "958a73705ca48671d3747deeab1a9fa0165c7454",
+        "is_verified": false,
+        "line_number": 1664
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "390113d1af6b5ece9a90ea6db402a0008b2a9d08",
+        "is_verified": false,
+        "line_number": 1668
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "27c070c58e194c6b2a6b1eeee137705a70e26ab6",
+        "is_verified": false,
+        "line_number": 1671
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f4eabe4c5b9c05cd02ccca0f948086e5ee9fff43",
+        "is_verified": false,
+        "line_number": 1714
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "36dbdb9d71cc9eb45a9d7f16fccec220ff67d2b1",
+        "is_verified": false,
+        "line_number": 1755
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "5c81cb3bbf077a30ebeea809bdba83483c8d5dd8",
+        "is_verified": false,
+        "line_number": 1758
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "05080d4369a5e3691eccb28e69d6988b360bcd22",
+        "is_verified": false,
+        "line_number": 1762
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "710e27fa7e2d80bebfa5cb9a0e3e2833021eab40",
+        "is_verified": false,
+        "line_number": 1766
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a2424039e79b5ea18e0d0b22f78cc7e6624fa4ad",
+        "is_verified": false,
+        "line_number": 1770
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "f0257d02d23f53e799476af74cf0386375d4b6c2",
+        "is_verified": false,
+        "line_number": 1774
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
+        "is_verified": false,
+        "line_number": 1779
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "749184805a59b4e245165000ff76d7e916f3efa5",
+        "is_verified": false,
+        "line_number": 1784
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "e8052d6a30f5c788cee736b595d620d412596dc8",
+        "is_verified": false,
+        "line_number": 1788
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "60f62b99a14507fe2d275d65d1bc793565396724",
+        "is_verified": false,
+        "line_number": 1792
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d534a8643166b53f9b72f567856071d026b7d454",
+        "is_verified": false,
+        "line_number": 1796
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "94afc05e19d3a49a8880bb36200596aed0a105d1",
+        "is_verified": false,
+        "line_number": 1799
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "bc001a988dc93a1d9f0b811c8b6f5ed71cd922e8",
+        "is_verified": false,
+        "line_number": 1804
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "d20d1d54c7478c3d210e559a91128c9ee7e31edb",
+        "is_verified": false,
+        "line_number": 1808
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "a36905f939ee26516ab756c0896b7e65328989dc",
+        "is_verified": false,
+        "line_number": 1812
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pnpm-lock.yaml",
+        "hashed_secret": "feac179f039c6552b05efe23c082dc7725c68b58",
+        "is_verified": false,
+        "line_number": 2154
+      }
+    ],
+    "src\\shared\\infrastructure\\config\\settings.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src\\shared\\infrastructure\\config\\settings.py",
+        "hashed_secret": "101b8b1b010f0eae4ef14b5987062ceacc15808b",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests\\apps\\api\\test_csrf.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\apps\\api\\test_csrf.py",
+        "hashed_secret": "ef6e31a362900d2dfe31d8d905e5d05b2ac96796",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "tests\\apps\\api\\test_studio.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\apps\\api\\test_studio.py",
+        "hashed_secret": "ef6e31a362900d2dfe31d8d905e5d05b2ac96796",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "tests\\contexts\\ai\\infrastructure\\test_provider_factory.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\contexts\\ai\\infrastructure\\test_provider_factory.py",
+        "hashed_secret": "547c26777a68f32d36e4914c97ad703b191ea0e1",
+        "is_verified": false,
+        "line_number": 110
+      }
+    ],
+    "tests\\contexts\\ai\\infrastructure\\test_text_generation_providers.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\contexts\\ai\\infrastructure\\test_text_generation_providers.py",
+        "hashed_secret": "547c26777a68f32d36e4914c97ad703b191ea0e1",
+        "is_verified": false,
+        "line_number": 283
+      }
+    ],
+    "tests\\unit\\infrastructure\\config\\test_settings.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "2ef61c29ba14553e82cdc9c840944a0de7b24abd",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "c281f43781aab4c4ea6bff545a5647b130296a8c",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "d9c57bff4723a9aa8e4be326e0c2e7df3906a039",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "25aabc85f369a81be0860c8a26ba4c6f12fbd6e6",
+        "is_verified": false,
+        "line_number": 120
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "246339798e610fe6cb0e8df2775e2e259268db34",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "384c9e7f247fc72b81c92c4c1746bfe6387beb1f",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "991eea3bff2ba006a69366e51dbc0c9616a63607",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "43214583c12e659da1502a097875ff8f12e572cc",
+        "is_verified": false,
+        "line_number": 216
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "5ce66ece05f4b65cfc2a532885a48ce1aca04c26",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "a1e184088ae04449e6846ad1701dceac2598d053",
+        "is_verified": false,
+        "line_number": 226
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "f8695a0db1cc51b8369801267b732b66b856dcda",
+        "is_verified": false,
+        "line_number": 244
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\unit\\infrastructure\\config\\test_settings.py",
+        "hashed_secret": "23378de365c6f510fc4dd4335162dd93acf736d8",
+        "is_verified": false,
+        "line_number": 254
+      }
+    ]
+  },
+  "generated_at": "2026-06-16T08:24:32Z"
+}

--- a/AUDIT_REPORT_Linus.md
+++ b/AUDIT_REPORT_Linus.md
@@ -1,0 +1,303 @@
+# PROJECT AUDIT REPORT: Novel-Engine / Novel Studio 0.3.0
+**Auditor:** Linus-Style Project Auditor  
+**Date:** 2026-06-16  
+**Verdict:** 🟡 NEEDS WORK  
+**Overall Score:** 58/100
+
+## Executive Summary (The Linus Rant)
+
+Look, the tests pass. The main user flow—write a project, ask the AI for a proposal, export the result—actually works. That puts this project head and shoulders above the usual hipster trash I have to review. Someone cared enough to build a real domain model, wire up SQLAlchemy 2.0, add CSRF, rate limiting, and a passing test suite. So it is not garbage.
+
+But it is **not acceptable either**.
+
+The single biggest problem is that this codebase lies to you. `AUDIT_REPORT.md` claims "zero remaining technical debt" while **thousands of lines of dead infrastructure rot on disk**: an entire outbox module, a circuit-breaker package, a generic health framework, a YAML config loader, and a Result-monad error handler that nobody imports. That is not "debt-free"; that is a cemetery with air-freshener sprayed on it.
+
+The second problem is that the project swallows errors like a black hole. Critical paths catch bare `Exception`, log nothing useful, and persist "failed" jobs. You will discover problems only when users complain, because the code is too polite to crash.
+
+The third problem is scale—and I do not mean "will it handle a million users." I mean **developer scale**. `services.py` is 1,962 lines. `repository.py` is 1,208 lines. `StudioPage.tsx` is 933 lines of React god-component. No AI guidance exists. A new contributor—or an AI—will touch one thing and break three others.
+
+If this PR crossed my desk, I would not NAK it outright. I would send it back with a short list of critical fixes and a strongly worded lecture about honesty in documentation.
+
+## Critical Findings (Fix These First or NAK)
+
+| # | Issue | File/Location | Severity | Dimension | Fix Hint |
+|---|-------|---------------|----------|-----------|----------|
+| 1 | FTS5 search query is escaped only for double quotes; user input reaches SQLite FTS5 MATCH syntax | `src/contexts/studio/application/services.py:608` | CRITICAL | Security | Use a strict token allow-list or SQLite `quote()`-style sanitization; add malicious-input tests |
+| 2 | `create_ai_proposal` catches bare `Exception`, persists a "failed" job, and swallows the traceback | `src/contexts/studio/application/services.py:1039` | CRITICAL | Error Handling | Catch only provider/HTTP/domain errors; log full traceback; let unexpected exceptions bubble |
+| 3 | `retry_job` catches bare `Exception` and persists failure string, hiding real bugs | `src/contexts/studio/application/services.py:1282` | CRITICAL | Error Handling | Narrow exception types; do not turn programming errors into persisted job failures |
+| 4 | `StudioDatabase()` singleton instantiated at module import time | `src/contexts/studio/infrastructure/database.py:136` | CRITICAL | Architecture | Replace with factory; instantiate only after config is ready |
+| 5 | FastAPI app created at module import time, wiring settings and store on `import` | `src/apps/api/main.py:282` | CRITICAL | Architecture | Expose `create_application()` factory; call it only from `main()` / tests |
+| 6 | Default LLM provider is `dashscope`, but all docs and Docker say `mock`; unconfigured default is advertised as default | `src/shared/infrastructure/config/settings.py:247` | CRITICAL | Doc-Project Consistency | Change code default to `mock`; align `LLM_MODEL` with docs |
+| 7 | Entire `src/events/outbox.py` (440 lines) is dead, misleading, and references a retired "simulation engine" | `src/events/outbox.py` | CRITICAL | Dead Code | Delete or archive; update `AUDIT_REPORT.md` |
+| 8 | `StudioPage.tsx` is a 933-line god component with ~20 states and ~15 effects | `frontend/src/features/studio/StudioPage.tsx` | CRITICAL | Code Quality | Split into `EditorPane`, `Navigator`, `Inspector`, `SearchPanel`, custom hooks |
+| 9 | `services.py` facade is still 1,962 lines of delegation after claimed refactor | `src/contexts/studio/application/services.py` | CRITICAL | Architecture | Split into per-service modules; make the facade thin or remove it |
+| 10 | `src/shared/interface/http/error_handlers.py` and `src/shared/application/result.py` are unused but documented as active | `src/shared/interface/http/error_handlers.py`, `src/shared/application/result.py` | CRITICAL | Dead Code | Delete or adopt consistently |
+
+## Detailed Findings by Dimension
+
+### 1. Functional Completeness
+
+- **Finding F1:** Missing project and document delete endpoints.
+  - **Evidence:** Verified route list in `src/contexts/studio/interface/http/router.py` lacks `DELETE /api/projects/{id}` and `DELETE /api/projects/{id}/documents/{id}`.
+  - **Why it matters:** A content-management app that cannot delete its core entities is incomplete. Users will accumulate junk projects forever.
+  - **Fix direction:** Add delete endpoints with ownership checks and cascade rules.
+
+- **Finding F2:** Import CLI exists but is undocumented and requires a magic `story.yaml` legacy layout.
+  - **Evidence:** `src/apps/cli/novel_engine.py` import command; `examples/demos/` only contains unrelated stale demos.
+  - **Why it matters:** A CLI feature that fails cryptically unless you know an undocumented schema is not a feature.
+  - **Fix direction:** Document the legacy workspace format or remove the import command until it has a real UX.
+
+- **Finding F3:** Broken demo script `demo_chronicler_integration.py` imports `src.agents.chronicler_agent`, which does not exist.
+  - **Evidence:** `examples/demos/demo_chronicler_integration.py:18`.
+  - **Why it matters:** Committed examples that crash on first run make the project look abandoned.
+  - **Fix direction:** Delete the demo or fix the import.
+
+- **Finding F4:** Health check framework is over-designed and unused; only a hardcoded DB `SELECT 1` is wired.
+  - **Evidence:** `src/shared/infrastructure/health/health_checker.py` unused; `src/apps/api/health.py` is the only wired implementation.
+  - **Why it matters:** Dead abstractions create the illusion of operational maturity.
+  - **Fix direction:** Delete the generic framework or replace `health.py` with it.
+
+### 2. Functional Availability
+
+- **Finding F5:** README is 35 lines and omits first-time setup essentials: `.env.local`, owner setup, LLM config, tests, Docker env vars.
+  - **Evidence:** `README.md`.
+  - **Why it matters:** A user can start the server but cannot authenticate or use AI without reading source.
+  - **Fix direction:** Expand README with copy-paste setup steps and env var table.
+
+- **Finding F6:** `docker compose up --build` fails out of the box because `SECURITY_SECRET_KEY` is required but README does not mention it.
+  - **Evidence:** `compose.yaml:16` uses `${SECURITY_SECRET_KEY:?Set SECURITY_SECRET_KEY}`; `README.md` Docker instruction is one line.
+  - **Why it matters:** Docker is supposed to be the easy path. Right now it is the trap door.
+  - **Fix direction:** Document required env vars before the Docker command.
+
+- **Finding F7:** CLI `--help` crashes in production mode without secrets.
+  - **Evidence:** `APP_ENVIRONMENT=production uv run novel-engine --help` raises pydantic validation error.
+  - **Why it matters:** Help should never require configuration.
+  - **Fix direction:** Defer settings validation until a command actually runs; use lazy factories.
+
+- **Finding F8:** Default LLM provider is `dashscope`, which is unconfigured by default, while docs claim `mock`.
+  - **Evidence:** `src/shared/infrastructure/config/settings.py:247` vs `.env.example` and `README.md`.
+  - **Why it matters:** The advertised default will fail for every new user.
+  - **Fix direction:** Default to `mock` and document how to switch providers.
+
+- **Finding F9:** `make` is referenced but unavailable on Windows; `pre-commit` and `trunk` are not installed by dependency sync.
+  - **Evidence:** UserSim report.
+  - **Why it matters:** Contributors on Windows or minimal environments cannot run the documented quality gates.
+  - **Fix direction:** Document cross-platform alternatives; add `pre-commit` and `trunk` as dev deps or remove the configs.
+
+- **Finding F10:** `MONITORING_METRICS_ENABLED` defaults to `true` in code but `false` in `.env.example`; fresh dev runs bind port 9090 and can fail.
+  - **Evidence:** `settings.py:382` vs `.env.example`.
+  - **Why it matters:** Silent port conflicts on startup are classic "works on my machine."
+  - **Fix direction:** Align defaults; consider disabling metrics by default in dev.
+
+### 3. Comments & Documentation
+
+- **Finding D1:** `AUDIT_REPORT.md` claims "zero remaining technical debt" while massive dead code remains.
+  - **Evidence:** `AUDIT_REPORT.md` vs. `src/events/outbox.py`, `src/shared/interface/http/`, `src/shared/infrastructure/circuit_breaker/`.
+  - **Why it matters:** Lying documentation is worse than no documentation.
+  - **Fix direction:** Rewrite `AUDIT_REPORT.md` honestly or remove the false claim.
+
+- **Finding D2:** Dead modules contain elaborate docstrings describing active behavior.
+  - **Evidence:** `src/events/outbox.py`, `src/shared/interface/http/error_handlers.py`, `src/shared/infrastructure/config/loader.py`.
+  - **Why it matters:** Comments that describe code nobody calls are traps for future maintainers.
+  - **Fix direction:** Delete the modules or rewrite docstrings to say "UNUSED — pending removal."
+
+- **Finding D3:** No `TODO`, `FIXME`, `XXX`, or `HACK` markers, but the dead modules themselves are silent technical debt.
+  - **Evidence:** Grep found none in `src/` or `frontend/src/`.
+  - **Why it matters:** The absence of markers does not mean the absence of debt; it means debt is unlabeled.
+  - **Fix direction:** Label dead code explicitly or remove it.
+
+- **Finding D4:** `settings.py` comment on `DEFAULT_SECRET_KEY` implies simple override; production actually rejects the default.
+  - **Evidence:** `src/shared/infrastructure/config/settings.py:17`.
+  - **Why it matters:** Misleading comments cause 3 AM debugging sessions.
+  - **Fix direction:** Rewrite the comment to describe the production validator and dev auto-generation.
+
+- **Finding D5:** `metrics_middleware.py` comment says "Metrics server should be started separately"; it is actually started in FastAPI lifespan.
+  - **Evidence:** `src/shared/infrastructure/middleware/metrics_middleware.py:15`.
+  - **Why it matters:** Comments that contradict implementation are lies.
+  - **Fix direction:** Fix the comment or move the server.
+
+- **Finding D6:** No `AGENTS.md`, `CHANGELOG.md`, or AI guidance exists.
+  - **Evidence:** Project root.
+  - **Why it matters:** A project at version 0.3.0 should have a changelog and contributor guidance.
+  - **Fix direction:** Add both.
+
+### 4. Code Quality
+
+- **Finding Q1:** Bare `except Exception` is everywhere in production code, swallowing real bugs.
+  - **Evidence:** `services.py:1039`, `services.py:1282`, `database.py:124`, `health_checker.py:243`, `loader.py:79`, `apps/api/health.py:56`, `metrics_middleware.py:83`, `logging_middleware.py:72`, `dashscope_text_generation_provider.py:613`, `openai_compatible_text_generation_provider.py:134`.
+  - **Why it matters:** You cannot debug what you cannot see. Programming errors become silent "unhealthy" or "failed" states.
+  - **Fix direction:** Catch specific exception families; let unexpected errors crash and be logged with tracebacks.
+
+- **Finding Q2:** `StudioPage.tsx` is 933 lines and violates every principle of component design.
+  - **Evidence:** `frontend/src/features/studio/StudioPage.tsx`.
+  - **Why it matters:** God components are impossible to test, review, or modify safely.
+  - **Fix direction:** Extract `EditorPane`, `Navigator`, `Inspector`, `SearchPanel`, `JobsPanel`, and hooks (`useProject`, `useAutosave`, `useAIProposal`).
+
+- **Finding Q3:** `services.py` is a 1,962-line facade over services that are themselves too large.
+  - **Evidence:** `src/contexts/studio/application/services.py`.
+  - **Why it matters:** The "refactor" moved code around without actually splitting responsibility.
+  - **Fix direction:** Create per-service modules (`project_service.py`, `document_service.py`, etc.) and a thin coordinator.
+
+- **Finding Q4:** `_coerce_value_to_schema` has ~20 branches and 18 return statements.
+  - **Evidence:** `src/contexts/ai/infrastructure/providers/dashscope_text_generation_provider.py:79`.
+  - **Why it matters:** Untestable, unreadable, and a bug factory for LLM output coercion.
+  - **Fix direction:** Decompose into type-specific coercers with a registry.
+
+- **Finding Q5:** `dashscope_text_generation_provider.py` falls back to `ast.literal_eval` on untrusted LLM output.
+  - **Evidence:** `src/contexts/ai/infrastructure/providers/dashscope_text_generation_provider.py:502-510`.
+  - **Why it matters:** Even "safe" eval is the wrong tool for remote data; malformed payloads pass through silently.
+  - **Fix direction:** Fail on non-JSON output or use a strict, auditable JSON repair utility.
+
+- **Finding Q6:** Ruff config is intentionally minimal and gives a false sense of quality.
+  - **Evidence:** `pyproject.toml:117` selects only `E4/E7/E9/F/I`.
+  - **Why it matters:** Complexity, broad exceptions, security, prints, and dead code are all disabled.
+  - **Fix direction:** Add `C90`, `BLE`, `S`, `T20`, `ARG`, `PLR`, `SIM`, `UP`, `B`; fix or explicitly ignore with reasons.
+
+- **Finding Q7:** Mypy errors exist in tests; CI likely runs `mypy src` only.
+  - **Evidence:** UserSim/CodeGrinder report 7 errors in `tests/`.
+  - **Why it matters:** Claiming strict mypy while exempting tests is hypocrisy.
+  - **Fix direction:** Fix test types or explicitly exclude tests with documented justification; run `mypy src tests` in CI.
+
+- **Finding Q8:** `AsyncClient` is lazily created and never explicitly closed.
+  - **Evidence:** `src/contexts/ai/infrastructure/providers/dashscope_text_generation_provider.py:319-330`.
+  - **Why it matters:** Resource leaks under load.
+  - **Fix direction:** Use context managers or lifespan hooks and call `aclose()`.
+
+- **Finding Q9:** Export hashing reads the entire file into memory.
+  - **Evidence:** `src/contexts/studio/application/services.py:817`.
+  - **Why it matters:** Large exports OOM the process.
+  - **Fix direction:** Stream the file through SHA-256.
+
+- **Finding Q10:** Copy-paste duplication in transport classes, job persistence, and retry handlers.
+  - **Evidence:** CodeGrinder DRY findings.
+  - **Why it matters:** Duplication means fixes happen in the wrong place.
+  - **Fix direction:** Extract shared helpers and registries.
+
+### 5. Architecture
+
+- **Finding A1:** Module-level singletons for database and app prevent configuration injection and test isolation.
+  - **Evidence:** `src/contexts/studio/infrastructure/database.py:136`, `src/apps/api/main.py:282`.
+  - **Why it matters:** Tests have to hack `sys.modules` to reset state.
+  - **Fix direction:** Use factories and dependency injection; never create stateful objects at import time.
+
+- **Finding A2:** Several packages exist only as architectural fiction.
+  - **Evidence:** `src/events/outbox.py`, `src/shared/interface/http/`, `src/shared/infrastructure/circuit_breaker/`, `src/shared/infrastructure/health/checks/`, `src/shared/infrastructure/config/loader.py`, `src/apps/workers/`.
+  - **Why it matters:** They bloat the codebase and confuse everyone.
+  - **Fix direction:** Delete or wire them into real behavior.
+
+- **Finding A3:** `src/shared/application/result.py` Result monad is unused except by an unused error handler.
+  - **Evidence:** CodeGrinder dead-code findings.
+  - **Why it matters:** Carrying a 406-line abstraction nobody uses is premature abstraction hell.
+  - **Fix direction:** Adopt it everywhere or delete it.
+
+- **Finding A4:** `StudioStore` proxy uses `__getattr__` to hide real dependencies.
+  - **Evidence:** `src/contexts/studio/application/services.py`.
+  - **Why it matters:** Untyped, magic forwarding makes the code hard to reason about and refactor.
+  - **Fix direction:** Inject concrete services into routers/handlers.
+
+- **Finding A5:** Frontend has only 12 source files and 1 unit test file for a complex SPA.
+  - **Evidence:** Scout report.
+  - **Why it matters:** The UI architecture cannot support growth.
+  - **Fix direction:** Split features into folders with co-located tests.
+
+### 6. Documentation-Project Consistency
+
+- **Finding C1:** Default LLM provider/model in code do not match `.env.example`, Docker, or README.
+  - **Evidence:** `settings.py:247-250` vs `.env.example`.
+  - **Why it matters:** The first-run experience is broken by default.
+  - **Fix direction:** Align all defaults to `mock` and `studio-copilot-v1`.
+
+- **Finding C2:** `config/env/.env.example` documents many settings the code ignores.
+  - **Evidence:** `MONITORING_ENABLED`, `MONITORING_TRACING_ENABLED`, `HEALTH_TIMEOUT_SECONDS`, `LOG_FILE_PATH`, `LOG_MAX_BYTES`, `API_WORKERS`, `APP_DEBUG`, `DB_POOL_SIZE`, etc.
+  - **Why it matters:** The env template is a wish list, not a contract.
+  - **Fix direction:** Remove dead vars or implement them.
+
+- **Finding C3:** Frontend env vars (`VITE_API_BASE_URL`, `VITE_API_TIMEOUT`, `VITE_API_PROXY_TARGET`) are undocumented.
+  - **Evidence:** `frontend/src/app/config.ts`, `frontend/vite.config.ts`.
+  - **Why it matters:** Frontend developers have to read Vite config to know how to point at the API.
+  - **Fix direction:** Add a frontend `.env.example` and README section.
+
+- **Finding C4:** Two `.env.example` files exist with different content.
+  - **Evidence:** `.env.example` (root) and `config/env/.env.example`.
+  - **Why it matters:** Users do not know which is authoritative.
+  - **Fix direction:** Consolidate into one canonical template.
+
+- **Finding C5:** OpenAPI snapshot is accurate and routes match implementation.
+  - **Evidence:** DocDetective verified route lists.
+  - **Why it matters:** This is the one area where documentation is honest.
+  - **Fix direction:** Keep it up to date automatically in CI.
+
+- **Finding C6:** `.envrc` references `CODEX_HOME` for a `.codex` directory that does not exist.
+  - **Evidence:** `config/env/.envrc`.
+  - **Why it matters:** Leftover from another project.
+  - **Fix direction:** Remove or fix.
+
+### 7. AI-Friendliness
+
+- **Finding AI1:** No `AGENTS.md`, `CLAUDE.md`, `AI_CONTEXT.md`, or `.cursorrules` exists.
+  - **Evidence:** AICoder report.
+  - **Why it matters:** An AI has to reverse-engineer Clean Architecture, the proxy singleton, SSOT checks, and the toolchain.
+  - **Fix direction:** Add `AGENTS.md` covering architecture, test commands, and hidden guardrails.
+
+- **Finding AI2:** Backend files exceed any reasonable context window.
+  - **Evidence:** `services.py` 1,962 lines, `repository.py` 1,208 lines.
+  - **Why it matters:** An AI cannot keep the whole contract in context when editing.
+  - **Fix direction:** Split into modules under 300 lines.
+
+- **Finding AI3:** Global `studio_store` proxy singleton is a hidden convention.
+  - **Evidence:** `src/contexts/studio/application/services.py`.
+  - **Why it matters:** Easy for an AI to call before configuration and get cryptic runtime errors.
+  - **Fix direction:** Document it as legacy; inject dependencies in new code.
+
+- **Finding AI4:** Frontend `StudioPage.tsx` is a 933-line trap for AI edits.
+  - **Evidence:** `frontend/src/features/studio/StudioPage.tsx`.
+  - **Why it matters:** AI will "successfully" edit it while subtly breaking one of many side effects.
+  - **Fix direction:** Decompose into hooks and components with isolated tests.
+
+- **Finding AI5:** Hidden CI guardrails (`check_ssot.py`, `check_repo_hygiene.py`, `check_openapi_snapshot.py`) can fail even when tests pass.
+  - **Evidence:** `scripts/qa/`.
+  - **Why it matters:** An AI can pass tests and still break `make validate`.
+  - **Fix direction:** Document these checks in `AGENTS.md` and provide a single offline validation command.
+
+## The Fix Roadmap (For the Repair AI)
+
+### Phase 1 (Critical)
+1. Harden `DocumentService.search` FTS5 query building against injection.
+2. Replace bare `except Exception` in `create_ai_proposal`, `retry_job`, and other production paths with specific exception types.
+3. Remove module-level singletons for `StudioDatabase` and FastAPI `app`; use factories.
+4. Change `LLMSettings.provider` default to `mock`; align `LLM_MODEL` with docs.
+5. Delete or archive dead modules: `src/events/outbox.py`, `src/shared/interface/http/`, `src/shared/infrastructure/circuit_breaker/`, `src/shared/infrastructure/health/checks/`, `src/shared/infrastructure/config/loader.py` + YAML examples, empty `cache/`, `policies/`, `workers/`.
+6. Delete broken demo `examples/demos/demo_chronicler_integration.py`.
+7. Make CLI `--help` work in production without secrets (lazy settings validation).
+
+### Phase 2 (Major)
+1. Split `services.py` into per-service modules with a thin facade.
+2. Split `repository.py` into focused query/command classes or modules.
+3. Decompose `StudioPage.tsx` into components and custom hooks with tests.
+4. Fix or delete the `result.py` monad and unused error handlers.
+5. Add delete endpoints for projects and documents.
+6. Document or remove the import CLI until it has a real UX.
+7. Consolidate `.env.example` files and remove dead env vars.
+8. Document frontend env vars and Vite dev workflow in README.
+9. Fix mypy errors in tests and run `mypy src tests` in CI.
+10. Widen ruff ruleset and fix or explicitly justify suppressions.
+
+### Phase 3 (Polish)
+1. Add `AGENTS.md` and `CHANGELOG.md`.
+2. Rewrite `AUDIT_REPORT.md` honestly in English.
+3. Add a file-size CI gate (~300 lines).
+4. Close `AsyncClient` resources, use streaming SHA-256 for exports, and atomic file writes.
+5. Clean `pyproject.toml` Black target versions and coverage omit list.
+6. Remove committed `.coverage` and SQLite databases from repo.
+7. Vendor or pin SRI hashes for Swagger UI assets.
+8. Add unit tests for frontend features beyond `api.test.ts`.
+
+## Linus' Final Words
+
+This project is not hopeless. The tests pass, the domain model is sane, and someone clearly gave a damn about architecture. But **giving a damn is not enough**.
+
+You cannot claim "zero technical debt" while dragging a graveyard of unused modules behind you. You cannot call yourself "well-tested" when your lint config deliberately ignores complexity and security. And you cannot expect real users—or AIs—to navigate a 933-line React component and a 1,962-line Python facade without breaking something.
+
+Fix the critical issues first. Be honest about what is dead. Stop swallowing exceptions. Then we can talk about whether this is acceptable.
+
+Now get to work.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,76 @@
+# justfile — Novel-Engine AI Guardrails & Developer Commands
+# Install just: https://github.com/casey/just
+
+# Default recipe
+_default:
+    @just --list
+
+# Create a git snapshot before AI session
+snapshot msg="pre-ai-snapshot":
+    git add -A
+    git commit -m "{{ msg }}-$(date +%s)" || echo "Nothing to commit or already clean"
+
+# Rollback to the last snapshot and clean untracked AI artifacts
+rollback:
+    git reset --hard HEAD~1
+    git clean -fd
+    uv sync --extra dev --extra test
+    corepack pnpm install --frozen-lockfile
+    corepack pnpm --dir frontend install --frozen-lockfile
+
+# Kill all running AI processes (emergency brake)
+kill-ai:
+    pkill -f "codex" || true
+    pkill -f "kimi" || true
+    pkill -f "claude" || true
+    echo "All AI processes terminated"
+
+# Full panic: kill AI + rollback
+panic: kill-ai rollback
+
+# Regression checks after AI modifies code
+check:
+    @echo "=== Changed files ==="
+    git diff --name-only
+    @echo ""
+    @echo "=== Deleted safety keywords ==="
+    git diff | grep -E '^\-.*\b(raise|assert|validate|sanitize|escape|auth|permission)\b' || echo "None found"
+    @echo ""
+    @echo "=== New bare except patterns ==="
+    git diff | grep -E '^\+.*except\s+Exception' || echo "None found"
+    @echo ""
+    @echo "=== New SQL string concatenation ==="
+    git diff | grep -E '^\+.*f".*SELECT|INSERT|UPDATE|DELETE|MATCH' || echo "None found"
+
+# Full validation (run after any significant change)
+validate:
+    uv run pytest -q
+    uv run mypy src
+    uv run ruff check src tests
+    uv run bandit -r src
+    uv run lint-imports
+    corepack pnpm --dir frontend lint
+    corepack pnpm --dir frontend type-check
+    corepack pnpm --dir frontend test:unit
+    corepack pnpm --dir frontend build
+    corepack pnpm spec:validate
+    uv run python scripts/qa/check_openapi_snapshot.py
+
+# Backend-only validation
+validate-backend:
+    uv run pytest -q
+    uv run mypy src
+    uv run ruff check src tests
+    uv run bandit -r src
+    uv run lint-imports
+
+# Frontend-only validation
+validate-frontend:
+    corepack pnpm --dir frontend lint
+    corepack pnpm --dir frontend type-check
+    corepack pnpm --dir frontend test:unit
+    corepack pnpm --dir frontend build
+
+# Run performance baseline tests (if they exist)
+perf:
+    uv run pytest tests/performance/ -v || echo "No performance tests found"

--- a/scripts/ai/regression_check.py
+++ b/scripts/ai/regression_check.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Regression check after AI modifies code.
+
+Run this after any AI-assisted change to detect common anti-patterns
+introduced by AI: deleted safety code, bare except, hardcoded secrets,
+SQL/FTS5 string concatenation, etc.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SAFETY_KEYWORDS = ["raise", "validate", "sanitize", "escape", "auth", "permission"]
+DANGEROUS_PATTERNS = [
+    (r"^\+.*except\s+Exception\s*:", "bare except Exception"),
+    (r'^\+.*f".*\b(SELECT|INSERT|UPDATE|DELETE|MATCH)\b', "SQL/FTS5 f-string"),
+    (r"^\+.*sk-[a-zA-Z0-9]{20,}", "possible OpenAI key"),
+    (r"^\+.*password\s*=\s*['\"][^'\"]+['\"]", "hardcoded password"),
+    (r"^\+.*SECRET_KEY\s*=\s*['\"][^'\"]+['\"]", "hardcoded secret key"),
+]
+FORBIDDEN_PREFIXES = {
+    "alembic/versions/",
+    ".env",
+    "config/env/",
+    "data/",
+}
+
+
+def run_git_diff() -> str:
+    result = subprocess.run(
+        ["git", "diff", "--no-color"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return result.stdout
+
+
+def parse_diff(diff: str) -> tuple[dict[str, list[str]], dict[str, list[str]], set[str]]:
+    """Parse diff into per-file additions, deletions, and entirely-deleted files."""
+    additions: dict[str, list[str]] = {}
+    deletions: dict[str, list[str]] = {}
+    deleted_files: set[str] = set()
+
+    current_file: str | None = None
+    is_deleted = False
+
+    for line in diff.splitlines():
+        if line.startswith("diff --git a/"):
+            # Reset for new file
+            current_file = None
+            is_deleted = False
+            parts = line.split()
+            if len(parts) >= 4:
+                # parts[3] is b/<filename>; remove prefix to get current file.
+                current_file = parts[3].removeprefix("b/")
+        elif line == "deleted file mode 100644" or line == "deleted file mode 100755":
+            is_deleted = True
+            if current_file:
+                deleted_files.add(current_file)
+                current_file = None
+        elif line.startswith("--- a/"):
+            # old file path; nothing to do
+            pass
+        elif line.startswith("+++ /dev/null"):
+            # File was deleted entirely.
+            is_deleted = True
+            if current_file:
+                deleted_files.add(current_file)
+                current_file = None
+        elif line.startswith("+++ b/"):
+            # New file path; current_file already known from diff --git line
+            pass
+        elif current_file and line.startswith("+") and not line.startswith("+++"):
+            additions.setdefault(current_file, []).append(line)
+        elif current_file and line.startswith("-") and not line.startswith("---"):
+            deletions.setdefault(current_file, []).append(line)
+
+    return additions, deletions, deleted_files
+
+
+def check_deleted_safety_lines(
+    deletions: dict[str, list[str]], deleted_files: set[str]
+) -> list[str]:
+    issues: list[str] = []
+    for filename, lines in deletions.items():
+        if filename in deleted_files:
+            # Dead code removal is expected; do not flag every deleted line.
+            continue
+        if filename.startswith("tests/"):
+            # Test deletions are usually fine.
+            continue
+        for line in lines:
+            for keyword in SAFETY_KEYWORDS:
+                if re.search(rf"\b{keyword}\b", line):
+                    issues.append(f"[{filename}] Deleted safety keyword '{keyword}': {line}")
+                    break
+    return issues
+
+
+def check_dangerous_additions(additions: dict[str, list[str]]) -> list[str]:
+    issues: list[str] = []
+    for filename, lines in additions.items():
+        for line in lines:
+            for pattern, description in DANGEROUS_PATTERNS:
+                if re.search(pattern, line, re.IGNORECASE):
+                    issues.append(f"[{filename}] {description}: {line}")
+                    break
+    return issues
+
+
+def check_file_count(additions: dict[str, list[str]], deletions: dict[str, list[str]]) -> list[str]:
+    changed_files = set(additions) | set(deletions)
+    issues: list[str] = []
+    if len(changed_files) > 5:
+        issues.append(
+            f"AI changed {len(changed_files)} files. Consider splitting into smaller tasks."
+        )
+    for f in changed_files:
+        for prefix in FORBIDDEN_PREFIXES:
+            if f.startswith(prefix):
+                issues.append(f"AI modified forbidden zone: {f}")
+    return issues
+
+
+def main() -> int:
+    diff = run_git_diff()
+    if not diff.strip():
+        print("No diff found. Did you forget to make changes?")
+        return 0
+
+    additions, deletions, deleted_files = parse_diff(diff)
+
+    all_issues: list[str] = []
+    all_issues.extend(check_deleted_safety_lines(deletions, deleted_files))
+    all_issues.extend(check_dangerous_additions(additions))
+    all_issues.extend(check_file_count(additions, deletions))
+
+    if not all_issues:
+        print("[PASS] Regression check passed. No obvious AI anti-patterns detected.")
+        return 0
+
+    print("[WARN] Regression check found potential issues:\n")
+    for issue in all_issues:
+        print(f"  - {issue}")
+    print(f"\nTotal issues: {len(all_issues)}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add AI guardrail reference files for local assistant workflows: `.ai-guard` and `.cursorrules`.
- Add `detect-secrets` baseline and pre-commit hook to catch hardcoded secrets.
- Add `justfile` recipes for snapshot, rollback, panic, and validation workflows.
- Add `scripts/ai/regression_check.py` for local diff safety checks after AI-assisted edits.
- Update CI and pre-commit mypy coverage to run `mypy src tests`.
- Add `AUDIT_REPORT_Linus.md` as the read-only audit reference used by the remediation flow.

## Scope

This PR is intentionally tooling-only. It is rebased on top of the merged audit remediation PR and does not change product runtime behavior.

## Validation

Local validation completed after rebase onto current `main`:

```text
uv run ruff check src tests
uv run mypy src tests
uv run bandit -r src
uv run lint-imports
uv run python scripts\qa\check_ssot.py
uv run python scripts\qa\check_repo_hygiene.py
uv run python scripts\qa\check_openapi_snapshot.py
uv run pytest -q
corepack pnpm spec:validate
corepack pnpm --dir frontend lint
corepack pnpm --dir frontend format:check
corepack pnpm --dir frontend type-check
corepack pnpm --dir frontend test:unit
corepack pnpm --dir frontend build
corepack pnpm --dir frontend test:e2e:smoke
python -m py_compile scripts\ai\regression_check.py
```

Observed results:

- pytest: 190 passed, 1 skipped
- frontend unit: 2 files, 8 tests passed
- Playwright smoke: 1 passed
- Bandit/import-linter/QA/OpenSpec gates passed

Note: `scripts/ai/regression_check.py` is a local CLI utility. The repository's current Ruff gate remains `src tests`, matching CI and pre-commit scope.