### PR TITLE
chore: release v0.3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## 1. Project Overview
 
-**Name:** Novel-Engine / Novel Studio 0.3.0
+**Name:** Novel-Engine / Novel Studio 0.3.1
 **Stack:** Python 3.11+ (FastAPI + SQLAlchemy 2.0 + Alembic + Pydantic v2 + SQLite), React 18 + Vite + TypeScript
 **Package managers:** `uv` (Python), `pnpm` (Node, workspace root + frontend)
 **Current status:** Audit remediation branch ready for staging validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.1
+
+- Remediated Linus-style audit findings across security, architecture,
+  documentation, and dead code.
+- Added AI guardrails, local safety checks, and stronger CI/pre-commit mypy
+  coverage for tests.
+
 ## 0.3.0
 
 - Added the self-hosted Novel Studio API and React writing workspace.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Novel Studio
 
-Novel Studio `0.3.0` is a self-hosted single-author novel writing IDE. SQLite is
+Novel Studio `0.3.1` is a self-hosted single-author novel writing IDE. SQLite is
 the content authority and Markdown is the document syntax.
 
 ## First-Time Setup

--- a/docs/api/openapi.current.json
+++ b/docs/api/openapi.current.json
@@ -463,7 +463,7 @@
   "info": {
     "description": "Novel Studio API for projects, Markdown revisions, AI proposals, reviews, snapshots, exports, sessions, and durable jobs.",
     "title": "Novel Studio",
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/openspec/specs/novel-studio/spec.md
+++ b/openspec/specs/novel-studio/spec.md
@@ -12,9 +12,9 @@ product version from `pyproject.toml`, and MUST define product behavior in this
 capability specification.
 
 #### Scenario: Derived surfaces report the release version
-- **GIVEN** the project version is `0.3.0`
+- **GIVEN** the project version is `0.3.1`
 - **WHEN** the API, Studio, logs, monitoring metadata, and OpenAPI are produced
-- **THEN** each surface reports `0.3.0`
+- **THEN** each surface reports `0.3.1`
 - **AND** none requires an independent version override
 
 ### Requirement: SQLite authoring authority

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "novel-engine"
-version = "0.3.0"
+version = "0.3.1"
 description = "Self-hosted single-author novel writing studio"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/qa/check_ssot.py
+++ b/scripts/qa/check_ssot.py
@@ -15,8 +15,8 @@ def main() -> int:
     failures: list[str] = []
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     version = str(project["project"]["version"])
-    if version != "0.3.0":
-        failures.append(f"pyproject.toml must define release version 0.3.0, got {version}")
+    if version != "0.3.1":
+        failures.append(f"pyproject.toml must define release version 0.3.1, got {version}")
 
     package = json.loads((ROOT / "frontend" / "package.json").read_text(encoding="utf-8"))
     if "version" in package:

--- a/src/shared/infrastructure/config/settings.py
+++ b/src/shared/infrastructure/config/settings.py
@@ -28,7 +28,7 @@ def _package_version() -> str:
     try:
         return version("novel-engine")
     except PackageNotFoundError:
-        return "0.3.0"
+        return "0.3.1"
 
 
 def _settings_config(

--- a/src/shared/infrastructure/logging/config.py
+++ b/src/shared/infrastructure/logging/config.py
@@ -16,7 +16,7 @@ def configure_logging(
     log_level: str = "INFO",
     json_format: bool = False,
     service_name: str = "novel-engine",
-    service_version: str = "0.3.0",
+    service_version: str = "0.3.1",
 ) -> None:
     """Configure unified logging for the application.
 

--- a/tests/unit/infrastructure/config/test_settings.py
+++ b/tests/unit/infrastructure/config/test_settings.py
@@ -151,8 +151,8 @@ def test_project_version_defaults_to_package_version(
 
     settings = NovelEngineSettings()
 
-    assert settings.project_version == "0.3.0"
-    assert settings.api.version == "0.3.0"
+    assert settings.project_version == "0.3.1"
+    assert settings.api.version == "0.3.1"
 
 
 def test_production_settings_reject_unsafe_defaults(

--- a/uv.lock
+++ b/uv.lock
@@ -1183,7 +1183,7 @@ wheels = [
 
 [[package]]
 name = "novel-engine"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Align project/runtime/docs/OpenAPI version surfaces to `0.3.1`
- Add the `0.3.1` changelog entry for audit remediation and AI guardrails
- Update release-version SSOT expectations and config tests

## Validation
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run bandit -r src`
- `uv run lint-imports`
- `uv run pytest -q` (`190 passed, 1 skipped`)
- `uv run python scripts\qa\check_ssot.py`
- `uv run python scripts\qa\check_openapi_snapshot.py`
- `corepack pnpm spec:validate`
- `corepack pnpm --dir frontend lint`
- `corepack pnpm --dir frontend format:check`
- `corepack pnpm --dir frontend type-check`
- `corepack pnpm --dir frontend test` (`8 passed`)
- `corepack pnpm --dir frontend build`
- `corepack pnpm --dir frontend test:e2e:smoke` (`1 passed`)

No deployment performed.