### PR TITLE
[codex] harden runtime contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   documentation, and dead code.
 - Added AI guardrails, local safety checks, and stronger CI/pre-commit mypy
   coverage for tests.
+- Hardened AI proposal acceptance, app-owned API runtime settings, token bucket
+  cleanup, and frontend API response contract parsing.
 
 ## 0.3.0
 

--- a/frontend/src/app/api.test.ts
+++ b/frontend/src/app/api.test.ts
@@ -23,6 +23,20 @@ describe('Studio API client', () => {
     );
   });
 
+  it('rejects project payloads that do not match the API contract', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ projects: [{ id: 'p1' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    await expect(api.projects()).rejects.toThrow('Invalid projects[0].title');
+  });
+
   it('preserves revision conflict detail', async () => {
     vi.stubGlobal(
       'fetch',
@@ -72,14 +86,25 @@ describe('Studio API client', () => {
   it('sends X-CSRF-Token header on write requests when cookie is present', async () => {
     vi.stubGlobal('document', { cookie: 'novel_studio_csrf=test-csrf-token' });
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ id: 'p1' }), {
-        status: 201,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+      new Response(
+        JSON.stringify({
+          id: 'p1',
+          title: 'Title',
+          description: '',
+          settings: {},
+          import_hash: null,
+          created_at: '2026-06-25T00:00:00Z',
+          updated_at: '2026-06-25T00:00:00Z',
+        }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(api.createProject('Title', '')).resolves.toEqual({ id: 'p1' });
+    await expect(api.createProject('Title', '')).resolves.toMatchObject({ id: 'p1' });
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/projects',
       expect.objectContaining({

--- a/frontend/src/app/api.ts
+++ b/frontend/src/app/api.ts
@@ -1,17 +1,26 @@
 import { appConfig } from '@/app/config';
-import type {
-  DocumentKind,
-  ExportFormat,
-  Project,
-  Review,
-  Revision,
-  Session,
-  SetupStatus,
-  StudioDocument,
-  ProviderInfo,
-  StudioExport,
-  StudioJob,
-} from '@/app/types/studio';
+import {
+  parseDocuments,
+  parseOwnerSetup,
+  parseProject,
+  parseProjects,
+  parseProviders,
+  parseRevisions,
+  parseSearch,
+  parseSession,
+  parseSetupStatus,
+  parseStudioDocument,
+  parseVoid,
+} from '@/app/apiContract';
+import {
+  parseExport,
+  parseExports,
+  parseJob,
+  parseJobs,
+  parseReview,
+  parseReviews,
+} from '@/app/apiWorkflowContract';
+import type { DocumentKind, ExportFormat } from '@/app/types/studio';
 
 export class HttpError extends Error {
   constructor(
@@ -34,7 +43,13 @@ export function getCsrfToken(): string | undefined {
   return match?.[1];
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+type ResponseParser<T> = (value: unknown) => T;
+
+async function request<T>(
+  path: string,
+  init: RequestInit | undefined,
+  parse: ResponseParser<T>,
+): Promise<T> {
   const controller = new AbortController();
   const externalSignal = init?.signal;
   let timedOut = false;
@@ -87,8 +102,8 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
             : `Request failed with status ${response.status}`;
       throw new HttpError(message, response.status, detail);
     }
-    if (response.status === 204) return undefined as T;
-    return (await response.json()) as T;
+    if (response.status === 204) return parse(undefined);
+    return parse(await response.json());
   } finally {
     window.clearTimeout(timeout);
     externalSignal?.removeEventListener('abort', abortFromExternal);
@@ -96,6 +111,13 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 const json = (value: unknown) => JSON.stringify(value);
+
+const postJson = <T>(path: string, value: unknown, parse: ResponseParser<T>) =>
+  request(path, { method: 'POST', body: json(value) }, parse);
+const putJson = <T>(path: string, value: unknown, parse: ResponseParser<T>) =>
+  request(path, { method: 'PUT', body: json(value) }, parse);
+const patchJson = <T>(path: string, value: unknown, parse: ResponseParser<T>) =>
+  request(path, { method: 'PATCH', body: json(value) }, parse);
 
 async function downloadBlob(path: string): Promise<Blob> {
   const controller = new AbortController();
@@ -121,28 +143,19 @@ async function downloadBlob(path: string): Promise<Blob> {
 }
 
 export const api = {
-  setupStatus: () => request<SetupStatus>('/api/setup'),
+  setupStatus: () => request('/api/setup', undefined, parseSetupStatus),
   setupOwner: (username: string, password: string) =>
-    request<{ id: string; username: string }>('/api/setup', {
-      method: 'POST',
-      body: json({ username, password }),
-    }),
+    postJson('/api/setup', { username, password }, parseOwnerSetup),
   login: (username: string, password: string) =>
-    request<Session>('/api/session/login', {
-      method: 'POST',
-      body: json({ username, password }),
-    }),
-  guest: () => request<Session>('/api/session/guest', { method: 'POST' }),
-  session: () => request<Session>('/api/session'),
-  logout: () => request<void>('/api/session', { method: 'DELETE' }),
-  providers: () => request<{ providers: ProviderInfo[] }>('/api/providers'),
-  projects: (init?: RequestInit) => request<{ projects: Project[] }>('/api/projects', init),
-  project: (projectId: string) => request<Project>(`/api/projects/${projectId}`),
+    postJson('/api/session/login', { username, password }, parseSession),
+  guest: () => request('/api/session/guest', { method: 'POST' }, parseSession),
+  session: () => request('/api/session', undefined, parseSession),
+  logout: () => request('/api/session', { method: 'DELETE' }, parseVoid),
+  providers: () => request('/api/providers', undefined, parseProviders),
+  projects: (init?: RequestInit) => request('/api/projects', init, parseProjects),
+  project: (projectId: string) => request(`/api/projects/${projectId}`, undefined, parseProject),
   createProject: (title: string, description: string) =>
-    request<Project>('/api/projects', {
-      method: 'POST',
-      body: json({ title, description }),
-    }),
+    postJson('/api/projects', { title, description }, parseProject),
   createDocument: (
     projectId: string,
     payload: {
@@ -150,16 +163,13 @@ export const api = {
       title: string;
       content_markdown?: string;
     },
-  ) =>
-    request<StudioDocument>(`/api/projects/${projectId}/documents`, {
-      method: 'POST',
-      body: json(payload),
-    }),
+  ) => postJson(`/api/projects/${projectId}/documents`, payload, parseStudioDocument),
   reorderDocuments: (projectId: string, documentIds: string[]) =>
-    request<{ documents: StudioDocument[] }>(`/api/projects/${projectId}/documents/reorder`, {
-      method: 'PUT',
-      body: json({ document_ids: documentIds }),
-    }),
+    putJson(
+      `/api/projects/${projectId}/documents/reorder`,
+      { document_ids: documentIds },
+      parseDocuments,
+    ),
   saveDocument: (
     projectId: string,
     documentId: string,
@@ -169,14 +179,12 @@ export const api = {
       title?: string;
       metadata?: Record<string, unknown>;
     },
-  ) =>
-    request<StudioDocument>(`/api/projects/${projectId}/documents/${documentId}`, {
-      method: 'PUT',
-      body: json(payload),
-    }),
+  ) => putJson(`/api/projects/${projectId}/documents/${documentId}`, payload, parseStudioDocument),
   revisions: (projectId: string, documentId: string) =>
-    request<{ revisions: Revision[] }>(
+    request(
       `/api/projects/${projectId}/documents/${documentId}/revisions`,
+      undefined,
+      parseRevisions,
     ),
   restoreRevision: (
     projectId: string,
@@ -184,13 +192,16 @@ export const api = {
     revisionId: string,
     baseRevisionId: string,
   ) =>
-    request<StudioDocument>(
+    postJson(
       `/api/projects/${projectId}/documents/${documentId}/revisions/${revisionId}/restore`,
-      { method: 'POST', body: json({ base_revision_id: baseRevisionId }) },
+      { base_revision_id: baseRevisionId },
+      parseStudioDocument,
     ),
   search: (projectId: string, query: string) =>
-    request<{ results: Array<{ document_id: string; title: string; excerpt: string }> }>(
+    request(
       `/api/projects/${projectId}/search?q=${encodeURIComponent(query)}`,
+      undefined,
+      parseSearch,
     ),
   proposal: (
     projectId: string,
@@ -199,25 +210,25 @@ export const api = {
     instruction: string,
     provider: string,
   ) =>
-    request<StudioJob>(`/api/projects/${projectId}/documents/${documentId}/ai-proposals`, {
-      method: 'POST',
-      body: json({ operation, instruction, provider }),
-    }),
+    postJson(
+      `/api/projects/${projectId}/documents/${documentId}/ai-proposals`,
+      { operation, instruction, provider },
+      parseJob,
+    ),
   acceptProposal: (projectId: string, jobId: string) =>
-    request<StudioJob>(`/api/projects/${projectId}/ai-proposals/${jobId}/accept`, {
-      method: 'POST',
-    }),
+    request(
+      `/api/projects/${projectId}/ai-proposals/${jobId}/accept`,
+      { method: 'POST' },
+      parseJob,
+    ),
   reviews: (projectId: string) =>
-    request<{ reviews: Review[] }>(`/api/projects/${projectId}/reviews`),
+    request(`/api/projects/${projectId}/reviews`, undefined, parseReviews),
   createReview: (projectId: string) =>
-    request<Review>(`/api/projects/${projectId}/reviews`, { method: 'POST' }),
+    request(`/api/projects/${projectId}/reviews`, { method: 'POST' }, parseReview),
   exports: (projectId: string) =>
-    request<{ exports: StudioExport[] }>(`/api/projects/${projectId}/exports`),
+    request(`/api/projects/${projectId}/exports`, undefined, parseExports),
   createExport: (projectId: string, format: ExportFormat) =>
-    request<StudioExport>(`/api/projects/${projectId}/exports`, {
-      method: 'POST',
-      body: json({ format }),
-    }),
+    postJson(`/api/projects/${projectId}/exports`, { format }, parseExport),
   updateProject: (
     projectId: string,
     payload: {
@@ -225,19 +236,13 @@ export const api = {
       description?: string;
       settings?: Record<string, unknown>;
     },
-  ) =>
-    request<Project>(`/api/projects/${projectId}`, {
-      method: 'PATCH',
-      body: json(payload),
-    }),
+  ) => patchJson(`/api/projects/${projectId}`, payload, parseProject),
   deleteProject: (projectId: string) =>
-    request<void>(`/api/projects/${projectId}`, { method: 'DELETE' }),
+    request(`/api/projects/${projectId}`, { method: 'DELETE' }, parseVoid),
   deleteDocument: (projectId: string, documentId: string) =>
-    request<void>(`/api/projects/${projectId}/documents/${documentId}`, { method: 'DELETE' }),
-  jobs: (projectId: string) => request<{ jobs: StudioJob[] }>(`/api/projects/${projectId}/jobs`),
+    request(`/api/projects/${projectId}/documents/${documentId}`, { method: 'DELETE' }, parseVoid),
+  jobs: (projectId: string) => request(`/api/projects/${projectId}/jobs`, undefined, parseJobs),
   retryJob: (projectId: string, jobId: string) =>
-    request<StudioJob>(`/api/projects/${projectId}/jobs/${jobId}/retry`, {
-      method: 'POST',
-    }),
+    request(`/api/projects/${projectId}/jobs/${jobId}/retry`, { method: 'POST' }, parseJob),
   download: (path: string) => downloadBlob(path),
 };

--- a/frontend/src/app/apiContract.ts
+++ b/frontend/src/app/apiContract.ts
@@ -1,0 +1,253 @@
+import type {
+  DocumentKind,
+  Project,
+  ProviderInfo,
+  Revision,
+  Session,
+  SessionKind,
+  SetupStatus,
+  StudioDocument,
+} from '@/app/types/studio';
+
+export class ApiContractError extends Error {
+  constructor(label: string) {
+    super(`Invalid ${label}`);
+    Object.setPrototypeOf(this, ApiContractError.prototype);
+  }
+}
+
+type JsonRecord = Record<string, unknown>;
+
+const documentKinds = ['chapter', 'outline', 'character', 'world', 'note'] as const;
+const sessionKinds = ['owner', 'guest'] as const;
+
+export function fail(label: string): never {
+  throw new ApiContractError(label);
+}
+
+export function objectValue(value: unknown, label: string): JsonRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) fail(label);
+  return value as JsonRecord;
+}
+
+export function field(source: JsonRecord, key: string, parent: string): unknown {
+  if (!Object.prototype.hasOwnProperty.call(source, key)) fail(`${parent}.${key}`);
+  return source[key];
+}
+
+export function stringValue(value: unknown, label: string): string {
+  return typeof value === 'string' ? value : fail(label);
+}
+
+export function stringField(source: JsonRecord, key: string, parent: string): string {
+  return stringValue(field(source, key, parent), `${parent}.${key}`);
+}
+
+export function nullableString(value: unknown, label: string): string | null {
+  return value === null ? null : stringValue(value, label);
+}
+
+export function nullableStringField(
+  source: JsonRecord,
+  key: string,
+  parent: string,
+): string | null {
+  return nullableString(field(source, key, parent), `${parent}.${key}`);
+}
+
+export function numberField(source: JsonRecord, key: string, parent: string): number {
+  const value = field(source, key, parent);
+  return typeof value === 'number' && Number.isFinite(value) ? value : fail(`${parent}.${key}`);
+}
+
+export function booleanField(source: JsonRecord, key: string, parent: string): boolean {
+  const value = field(source, key, parent);
+  return typeof value === 'boolean' ? value : fail(`${parent}.${key}`);
+}
+
+export function recordField(
+  source: JsonRecord,
+  key: string,
+  parent: string,
+): Record<string, unknown> {
+  return objectValue(field(source, key, parent), `${parent}.${key}`);
+}
+
+export function arrayValue<T>(
+  value: unknown,
+  label: string,
+  parseItem: (item: unknown, index: number) => T,
+): T[] {
+  return Array.isArray(value) ? value.map(parseItem) : fail(label);
+}
+
+export function arrayField<T>(
+  source: JsonRecord,
+  key: string,
+  parent: string,
+  parseItem: (item: unknown, index: number) => T,
+): T[] {
+  return arrayValue(field(source, key, parent), `${parent}.${key}`, parseItem);
+}
+
+export function literalValue<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  label: string,
+): T[number] {
+  return typeof value === 'string' && allowed.includes(value) ? (value as T[number]) : fail(label);
+}
+
+export function literalField<T extends readonly string[]>(
+  source: JsonRecord,
+  key: string,
+  parent: string,
+  allowed: T,
+): T[number] {
+  return literalValue(field(source, key, parent), allowed, `${parent}.${key}`);
+}
+
+function parseDocument(value: unknown, label = 'document'): StudioDocument {
+  const item = objectValue(value, label);
+  return {
+    id: stringField(item, 'id', label),
+    project_id: stringField(item, 'project_id', label),
+    kind: literalField(item, 'kind', label, documentKinds) as DocumentKind,
+    title: stringField(item, 'title', label),
+    position: numberField(item, 'position', label),
+    current_revision_id: stringField(item, 'current_revision_id', label),
+    content_markdown: stringField(item, 'content_markdown', label),
+    metadata: recordField(item, 'metadata', label),
+    revision_source: stringField(item, 'revision_source', label),
+    word_count: numberField(item, 'word_count', label),
+    created_at: stringField(item, 'created_at', label),
+    updated_at: stringField(item, 'updated_at', label),
+  };
+}
+
+export function parseProject(value: unknown, label = 'project'): Project {
+  const item = objectValue(value, label);
+  const documents = item.documents;
+  return {
+    id: stringField(item, 'id', label),
+    title: stringField(item, 'title', label),
+    description: stringField(item, 'description', label),
+    settings: recordField(item, 'settings', label),
+    import_hash: nullableStringField(item, 'import_hash', label),
+    created_at: stringField(item, 'created_at', label),
+    updated_at: stringField(item, 'updated_at', label),
+    ...(documents === undefined
+      ? {}
+      : {
+          documents: arrayValue(documents, `${label}.documents`, (entry, index) =>
+            parseDocument(entry, `${label}.documents[${index}]`),
+          ),
+        }),
+  };
+}
+
+export function parseProjects(value: unknown): { projects: Project[] } {
+  const item = objectValue(value, 'projects response');
+  return { projects: arrayField(item, 'projects', 'projects response', parseProjectListItem) };
+}
+
+function parseProjectListItem(value: unknown, index: number): Project {
+  return parseProject(value, `projects[${index}]`);
+}
+
+export function parseSetupStatus(value: unknown): SetupStatus {
+  const item = objectValue(value, 'setup');
+  return {
+    owner_configured: booleanField(item, 'owner_configured', 'setup'),
+    version: stringField(item, 'version', 'setup'),
+  };
+}
+
+export function parseOwnerSetup(value: unknown): { id: string; username: string } {
+  const item = objectValue(value, 'owner');
+  return { id: stringField(item, 'id', 'owner'), username: stringField(item, 'username', 'owner') };
+}
+
+export function parseSession(value: unknown): Session {
+  const item = objectValue(value, 'session');
+  return {
+    session_id: stringField(item, 'session_id', 'session'),
+    kind: literalField(item, 'kind', 'session', sessionKinds) as SessionKind,
+    owner_id: nullableStringField(item, 'owner_id', 'session'),
+    expires_at: nullableStringField(item, 'expires_at', 'session'),
+  };
+}
+
+function parseProvider(value: unknown, label: string): ProviderInfo {
+  const item = objectValue(value, label);
+  return {
+    provider: stringField(item, 'provider', label),
+    configured: booleanField(item, 'configured', label),
+    model: nullableStringField(item, 'model', label),
+    is_default: booleanField(item, 'is_default', label),
+  };
+}
+
+export function parseProviders(value: unknown): { providers: ProviderInfo[] } {
+  const item = objectValue(value, 'providers response');
+  return {
+    providers: arrayField(item, 'providers', 'providers response', (entry, index) =>
+      parseProvider(entry, `providers[${index}]`),
+    ),
+  };
+}
+
+export const parseStudioDocument = parseDocument;
+
+export function parseDocuments(value: unknown): { documents: StudioDocument[] } {
+  const item = objectValue(value, 'documents response');
+  return {
+    documents: arrayField(item, 'documents', 'documents response', (entry, index) =>
+      parseDocument(entry, `documents[${index}]`),
+    ),
+  };
+}
+
+function parseRevision(value: unknown, label: string): Revision {
+  const item = objectValue(value, label);
+  return {
+    id: stringField(item, 'id', label),
+    document_id: stringField(item, 'document_id', label),
+    parent_revision_id: nullableStringField(item, 'parent_revision_id', label),
+    revision_number: numberField(item, 'revision_number', label),
+    content_markdown: stringField(item, 'content_markdown', label),
+    metadata: recordField(item, 'metadata', label),
+    source: stringField(item, 'source', label),
+    word_count: numberField(item, 'word_count', label),
+    created_at: stringField(item, 'created_at', label),
+  };
+}
+
+export function parseRevisions(value: unknown): { revisions: Revision[] } {
+  const item = objectValue(value, 'revisions response');
+  return {
+    revisions: arrayField(item, 'revisions', 'revisions response', (entry, index) =>
+      parseRevision(entry, `revisions[${index}]`),
+    ),
+  };
+}
+
+export function parseSearch(value: unknown): {
+  results: Array<{ document_id: string; title: string; excerpt: string }>;
+} {
+  const item = objectValue(value, 'search response');
+  return {
+    results: arrayField(item, 'results', 'search response', (entry, index) => {
+      const result = objectValue(entry, `results[${index}]`);
+      return {
+        document_id: stringField(result, 'document_id', `results[${index}]`),
+        title: stringField(result, 'title', `results[${index}]`),
+        excerpt: stringField(result, 'excerpt', `results[${index}]`),
+      };
+    }),
+  };
+}
+
+export function parseVoid(): void {
+  return undefined;
+}

--- a/frontend/src/app/apiWorkflowContract.ts
+++ b/frontend/src/app/apiWorkflowContract.ts
@@ -1,0 +1,157 @@
+import type {
+  ExportFormat,
+  Review,
+  ReviewIssue,
+  StudioExport,
+  StudioJob,
+  StudioJobEvent,
+  StudioJobKind,
+  StudioJobOperation,
+  StudioJobStatus,
+} from '@/app/types/studio';
+
+import {
+  arrayField,
+  literalField,
+  nullableString,
+  nullableStringField,
+  numberField,
+  objectValue,
+  recordField,
+  stringField,
+  stringValue,
+} from '@/app/apiContract';
+
+const exportFormats = ['markdown', 'docx', 'epub'] as const;
+const jobKinds = ['proposal', 'review', 'export'] as const;
+const jobOperations = ['continue', 'rewrite', 'generate', 'review', 'export'] as const;
+const jobStatuses = ['pending', 'running', 'completed', 'failed', 'interrupted'] as const;
+const severities = ['blocker', 'warning', 'suggestion'] as const;
+
+function optionalString(
+  source: Record<string, unknown>,
+  key: string,
+  label: string,
+): string | undefined {
+  const value = source[key];
+  return value === undefined ? undefined : stringValue(value, label);
+}
+
+function parseIssue(value: unknown, label: string): ReviewIssue {
+  const item = objectValue(value, label);
+  return {
+    id: stringField(item, 'id', label),
+    document_id: nullableStringField(item, 'document_id', label),
+    severity: literalField(item, 'severity', label, severities),
+    code: stringField(item, 'code', label),
+    message: stringField(item, 'message', label),
+    suggestion: stringField(item, 'suggestion', label),
+    evidence: recordField(item, 'evidence', label),
+  };
+}
+
+export function parseReview(value: unknown, label = 'review'): Review {
+  const item = objectValue(value, label);
+  return {
+    id: stringField(item, 'id', label),
+    project_id: stringField(item, 'project_id', label),
+    snapshot_id: stringField(item, 'snapshot_id', label),
+    provider: stringField(item, 'provider', label),
+    model: stringField(item, 'model', label),
+    summary: stringField(item, 'summary', label),
+    created_at: stringField(item, 'created_at', label),
+    issues: arrayField(item, 'issues', label, (issue, index) =>
+      parseIssue(issue, `${label}.issues[${index}]`),
+    ),
+  };
+}
+
+export function parseReviews(value: unknown): { reviews: Review[] } {
+  const item = objectValue(value, 'reviews response');
+  return {
+    reviews: arrayField(item, 'reviews', 'reviews response', (entry, index) =>
+      parseReview(entry, `reviews[${index}]`),
+    ),
+  };
+}
+
+function parseJobEvent(value: unknown, label: string): StudioJobEvent {
+  const item = objectValue(value, label);
+  return {
+    id: stringField(item, 'id', label),
+    status: literalField(item, 'status', label, jobStatuses) as StudioJobStatus,
+    details: recordField(item, 'details', label),
+    created_at: stringField(item, 'created_at', label),
+  };
+}
+
+export function parseJob(value: unknown, label = 'job'): StudioJob {
+  const item = objectValue(value, label);
+  const result = recordField(item, 'result', label);
+  return {
+    id: stringField(item, 'id', label),
+    project_id: stringField(item, 'project_id', label),
+    document_id: nullableStringField(item, 'document_id', label),
+    kind: literalField(item, 'kind', label, jobKinds) as StudioJobKind,
+    operation: literalField(item, 'operation', label, jobOperations) as StudioJobOperation,
+    status: literalField(item, 'status', label, jobStatuses) as StudioJobStatus,
+    provider: stringField(item, 'provider', label),
+    model: stringField(item, 'model', label),
+    request: recordField(item, 'request', label),
+    result: {
+      proposal_markdown: optionalString(
+        result,
+        'proposal_markdown',
+        `${label}.result.proposal_markdown`,
+      ),
+      base_revision_id: optionalString(
+        result,
+        'base_revision_id',
+        `${label}.result.base_revision_id`,
+      ),
+      accepted_revision_id:
+        result.accepted_revision_id === undefined
+          ? undefined
+          : nullableString(result.accepted_revision_id, `${label}.result.accepted_revision_id`),
+    },
+    error: nullableStringField(item, 'error', label),
+    retry_of_job_id: nullableStringField(item, 'retry_of_job_id', label),
+    events: arrayField(item, 'events', label, (event, index) =>
+      parseJobEvent(event, `${label}.events[${index}]`),
+    ),
+    created_at: stringField(item, 'created_at', label),
+    updated_at: stringField(item, 'updated_at', label),
+  };
+}
+
+export function parseJobs(value: unknown): { jobs: StudioJob[] } {
+  const item = objectValue(value, 'jobs response');
+  return {
+    jobs: arrayField(item, 'jobs', 'jobs response', (entry, index) =>
+      parseJob(entry, `jobs[${index}]`),
+    ),
+  };
+}
+
+export function parseExport(value: unknown, label = 'export'): StudioExport {
+  const item = objectValue(value, label);
+  return {
+    id: stringField(item, 'id', label),
+    project_id: stringField(item, 'project_id', label),
+    snapshot_id: stringField(item, 'snapshot_id', label),
+    format: literalField(item, 'format', label, exportFormats) as ExportFormat,
+    size_bytes: numberField(item, 'size_bytes', label),
+    checksum_sha256: stringField(item, 'checksum_sha256', label),
+    created_at: stringField(item, 'created_at', label),
+    download_url: stringField(item, 'download_url', label),
+  };
+}
+
+export function parseExports(value: unknown): { exports: StudioExport[] } {
+  const item = objectValue(value, 'exports response');
+  return {
+    exports: arrayField(item, 'exports', 'exports response', (entry, index) =>
+      parseExport(entry, `exports[${index}]`),
+    ),
+  };
+}

--- a/openspec/specs/novel-studio/spec.md
+++ b/openspec/specs/novel-studio/spec.md
@@ -51,6 +51,12 @@ author accepts the proposal.
 - **WHEN** the author accepts it
 - **THEN** the proposed Markdown is saved as a new revision
 
+#### Scenario: Reject an invalid proposal acceptance
+- **GIVEN** an AI proposal job failed or contains no proposed Markdown
+- **WHEN** the author attempts to accept it
+- **THEN** the system rejects the acceptance
+- **AND** no document revision is created
+
 ### Requirement: Snapshot-bound review and export
 Reviews and exports MUST reference immutable project snapshots.
 

--- a/src/apps/api/health.py
+++ b/src/apps/api/health.py
@@ -7,13 +7,12 @@ import sys
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from src.contexts.studio.application.services import StudioStore
 from src.contexts.studio.interface.http.dependencies import StudioStoreDependency
-from src.shared.infrastructure.config.settings import get_settings
 
 health_router = APIRouter()
 
@@ -95,9 +94,9 @@ async def readiness_probe(store: StudioStoreDependency) -> JSONResponse:
 
 
 @health_router.get("/version", response_model=dict[str, str])
-async def version() -> dict[str, str]:
+async def version(request: Request) -> dict[str, str]:
     """Return application version metadata."""
-    settings = get_settings()
+    settings = request.app.state.settings
     return {
         "version": settings.project_version,
         "name": settings.project_name,

--- a/src/apps/api/runtime.py
+++ b/src/apps/api/runtime.py
@@ -8,10 +8,14 @@ from functools import partial
 import anyio
 from fastapi import FastAPI
 
-from src.contexts.studio.application.services import StudioStore
-from src.contexts.studio.infrastructure.ai_provider import (
-    create_studio_text_generation_provider,
+from src.contexts.ai.application.ports.text_generation_port import (
+    TextGenerationProvider,
+    TextGenerationProviderName,
 )
+from src.contexts.ai.infrastructure.providers.provider_factory import (
+    create_text_generation_provider,
+)
+from src.contexts.studio.application.services import StudioStore
 from src.contexts.studio.infrastructure.database import (
     StudioDatabase,
     create_studio_database,
@@ -35,11 +39,18 @@ class StudioRuntimeNotConfiguredError(RuntimeError):
 
 def create_runtime(settings: NovelEngineSettings) -> StudioRuntime:
     database = create_studio_database(settings)
+
+    def ai_provider_factory(
+        provider_name: TextGenerationProviderName,
+        model_name: str,
+    ) -> TextGenerationProvider:
+        return create_text_generation_provider(settings, provider_name, model_name)
+
     return StudioRuntime(
         store=StudioStore(
             repository=SqlAlchemyStudioRepository(database),
             data_dir=settings.data_dir,
-            ai_provider_factory=create_studio_text_generation_provider,
+            ai_provider_factory=ai_provider_factory,
             export_writers=DEFAULT_EXPORT_WRITERS,
         ),
         database=database,

--- a/src/contexts/studio/application/services/ai_service.py
+++ b/src/contexts/studio/application/services/ai_service.py
@@ -29,6 +29,10 @@ from src.contexts.studio.application.services.document_service import DocumentSe
 __all__ = ["AIService"]
 
 
+def _resolved_token_count(value: int | None, text: str) -> int:
+    return value if value is not None else _word_count(text)
+
+
 class AIService:
     """AI-driven manuscript proposals."""
 
@@ -99,15 +103,13 @@ class AIService:
         )
         try:
             result = await generation_provider.generate_structured(task)
-            prompt_tokens = result.prompt_tokens
-            completion_tokens = result.completion_tokens
             proposal_markdown = (
                 result.content.get("chapter_markdown") or result.raw_text
             )
             return (
                 _sanitize_chapter_markdown(str(proposal_markdown)),
-                prompt_tokens,
-                completion_tokens,
+                result.prompt_tokens,
+                result.completion_tokens,
             )
         finally:
             close = getattr(generation_provider, "aclose", None)
@@ -137,10 +139,8 @@ class AIService:
         return (
             proposal,
             revision.id,
-            prompt_tokens if prompt_tokens is not None else _word_count(instruction),
-            completion_tokens
-            if completion_tokens is not None
-            else _word_count(proposal),
+            _resolved_token_count(prompt_tokens, instruction),
+            _resolved_token_count(completion_tokens, proposal),
         )
 
     async def create_ai_proposal(
@@ -168,7 +168,6 @@ class AIService:
                 provider=provider,
                 model=model,
             )
-            proposal_markdown = _sanitize_chapter_markdown(proposal_markdown)
         except TextGenerationProviderError as exc:
             logger.exception(
                 "ai_proposal_failed",
@@ -268,13 +267,10 @@ class AIService:
             job_id=job.id,
             provider=provider,
             model=model,
-            prompt_tokens=(
-                prompt_tokens if prompt_tokens is not None else _word_count(instruction)
-            ),
-            completion_tokens=(
-                completion_tokens
-                if completion_tokens is not None
-                else _word_count(proposal_markdown)
+            prompt_tokens=_resolved_token_count(prompt_tokens, instruction),
+            completion_tokens=_resolved_token_count(
+                completion_tokens,
+                proposal_markdown,
             ),
             request_evidence_json=dump_json(
                 {"operation": operation, "base_revision_id": base_revision_id}
@@ -372,12 +368,18 @@ class AIService:
         )
         if job.kind != "proposal" or job.document_id is None:
             raise NotFound("AI proposal not found.")
+        if job.status != "completed":
+            raise InvalidOperation("Only a completed proposal can be accepted.")
         result = cast(dict[str, Any], _safe_load_json(job.result_json))
         request = cast(dict[str, Any], _safe_load_json(job.request_json))
         if result.get("accepted_revision_id"):
             return _job_payload(job)
         document_id = job.document_id
         proposal = str(result.get("proposal_markdown", ""))
+        if not proposal.strip():
+            raise InvalidOperation(
+                "Only a completed proposal with content can be accepted."
+            )
         base_revision_id = cast(str | None, request.get("base_revision_id"))
 
         document_service = DocumentService(self._repository)

--- a/src/contexts/studio/interface/http/session_router.py
+++ b/src/contexts/studio/interface/http/session_router.py
@@ -14,7 +14,6 @@ from src.contexts.studio.domain.principal import Principal
 from src.contexts.studio.interface.http.dependencies import StudioStoreDependency
 from src.contexts.studio.interface.http.errors import _handle_domain_exceptions
 from src.contexts.studio.interface.http.schemas import LoginRequest, OwnerSetupRequest
-from src.shared.infrastructure.config.settings import get_settings
 
 session_router = APIRouter(tags=["studio"])
 
@@ -24,12 +23,13 @@ def _session_cookie(
     token: str,
     *,
     max_age: int | None,
+    secure: bool,
 ) -> None:
     response.set_cookie(
         SESSION_COOKIE,
         token,
         httponly=True,
-        secure=get_settings().is_production,
+        secure=secure,
         samesite="lax",
         max_age=max_age,
         path="/",
@@ -41,12 +41,13 @@ def _csrf_cookie(
     token: str,
     *,
     max_age: int | None,
+    secure: bool,
 ) -> None:
     response.set_cookie(
         CSRF_COOKIE,
         token,
         httponly=False,
-        secure=get_settings().is_production,
+        secure=secure,
         samesite="lax",
         max_age=max_age,
         path="/",
@@ -107,10 +108,12 @@ def _principal_payload(principal: Principal) -> dict[str, Any]:
 
 
 @session_router.get("/setup")
-async def setup_status(store: StudioStoreDependency) -> dict[str, Any]:
+async def setup_status(
+    request: Request, store: StudioStoreDependency
+) -> dict[str, Any]:
     return {
         "owner_configured": store.owner_exists(),
-        "version": get_settings().project_version,
+        "version": request.app.state.settings.project_version,
     }
 
 
@@ -126,6 +129,7 @@ async def setup_owner(
 @session_router.post("/session/login")
 @_handle_domain_exceptions
 async def login(
+    request: Request,
     payload: LoginRequest,
     response: Response,
     store: StudioStoreDependency,
@@ -135,20 +139,23 @@ async def login(
         payload.password,
     )
     max_age = 60 * 60 * 24 * 30
-    _session_cookie(response, token, max_age=max_age)
-    _csrf_cookie(response, csrf_token, max_age=max_age)
+    secure = request.app.state.settings.is_production
+    _session_cookie(response, token, max_age=max_age, secure=secure)
+    _csrf_cookie(response, csrf_token, max_age=max_age, secure=secure)
     return _principal_payload(principal)
 
 
 @session_router.post("/session/guest", status_code=status.HTTP_201_CREATED)
 async def guest_session(
+    request: Request,
     response: Response,
     store: StudioStoreDependency,
 ) -> dict[str, Any]:
     token, csrf_token, principal = store.create_guest_session()
     max_age = int(GUEST_TTL.total_seconds())
-    _session_cookie(response, token, max_age=max_age)
-    _csrf_cookie(response, csrf_token, max_age=max_age)
+    secure = request.app.state.settings.is_production
+    _session_cookie(response, token, max_age=max_age, secure=secure)
+    _csrf_cookie(response, csrf_token, max_age=max_age, secure=secure)
     return _principal_payload(principal)
 
 
@@ -176,9 +183,9 @@ async def logout(
 
 
 @session_router.get("/providers")
-async def providers(principal: PrincipalDependency) -> dict[str, Any]:
+async def providers(request: Request, principal: PrincipalDependency) -> dict[str, Any]:
     del principal
-    settings = get_settings()
+    settings = request.app.state.settings
     items = []
     for provider in ("mock", "dashscope", "openai_compatible"):
         items.append(

--- a/src/contexts/studio/interface/http/workflow_router.py
+++ b/src/contexts/studio/interface/http/workflow_router.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import FileResponse
 
 from src.contexts.studio.domain.exceptions import InvalidOperation, NotFound
@@ -16,7 +16,6 @@ from src.contexts.studio.interface.http.schemas import (
     LegacyPathRequest,
 )
 from src.contexts.studio.interface.http.session_router import PrincipalDependency
-from src.shared.infrastructure.config.settings import get_settings
 
 workflow_router = APIRouter(tags=["studio"])
 
@@ -29,13 +28,13 @@ def _require_owner(principal: Principal) -> None:
         )
 
 
-def _web_import_source(source: str) -> Path:
+def _web_import_source(source: str, data_dir: Path) -> Path:
     if source in {".", ".."} or "/" in source or "\\" in source:
         raise InvalidOperation(
             "Web imports must name a workspace directory under data/imports."
         )
 
-    import_root = (get_settings().data_dir / "imports").resolve()
+    import_root = (data_dir / "imports").resolve()
     import_root.mkdir(parents=True, exist_ok=True)
     for candidate in import_root.iterdir():
         if candidate.name != source or candidate.is_symlink() or not candidate.is_dir():
@@ -52,9 +51,11 @@ async def create_ai_proposal(
     project_id: str,
     document_id: str,
     payload: AIProposalRequest,
+    request: Request,
     principal: PrincipalDependency,
     store: StudioStoreDependency,
 ) -> dict[str, Any]:
+    settings = request.app.state.settings
     return await store.create_ai_proposal(
         principal,
         project_id,
@@ -62,7 +63,7 @@ async def create_ai_proposal(
         operation=payload.operation,
         instruction=payload.instruction,
         provider=payload.provider,
-        model=get_settings().llm.resolved_model(payload.provider),
+        model=settings.llm.resolved_model(payload.provider),
     )
 
 
@@ -165,22 +166,26 @@ async def download_export(
 @_handle_domain_exceptions
 async def preview_import(
     payload: LegacyPathRequest,
+    request: Request,
     principal: PrincipalDependency,
     store: StudioStoreDependency,
 ) -> dict[str, Any]:
     _require_owner(principal)
-    return store.preview_legacy_workspace(_web_import_source(payload.source))
+    return store.preview_legacy_workspace(
+        _web_import_source(payload.source, request.app.state.settings.data_dir)
+    )
 
 
 @workflow_router.post("/imports", status_code=status.HTTP_201_CREATED)
 @_handle_domain_exceptions
 async def import_workspace(
     payload: LegacyPathRequest,
+    request: Request,
     principal: PrincipalDependency,
     store: StudioStoreDependency,
 ) -> dict[str, Any]:
     _require_owner(principal)
     return store.import_legacy_workspace(
         principal,
-        _web_import_source(payload.source),
+        _web_import_source(payload.source, request.app.state.settings.data_dir),
     )

--- a/src/shared/infrastructure/rate_limit/token_bucket.py
+++ b/src/shared/infrastructure/rate_limit/token_bucket.py
@@ -170,3 +170,4 @@ class TokenBucketRateLimiter:
             for k in expired:
                 self._tokens.pop(k, None)
                 self._last_update.pop(k, None)
+                self._locks.pop(k, None)

--- a/tests/apps/api/test_app_owned_settings.py
+++ b/tests/apps/api/test_app_owned_settings.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.apps.api.runtime import create_runtime
+from src.contexts.ai.infrastructure.providers.dashscope_text_generation_provider import (
+    DashScopeTextGenerationProvider,
+)
+from src.shared.infrastructure.config.settings import (
+    DatabaseSettings,
+    LLMSettings,
+    NovelEngineSettings,
+    reset_settings,
+)
+
+
+def test_web_import_uses_app_owned_data_dir_after_global_settings_change(
+    canonical_app: FastAPI,
+    canonical_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    canonical_client.post(
+        "/api/setup",
+        json={"username": "owner", "password": "owner-password-123"},
+    )
+    canonical_client.post(
+        "/api/session/login",
+        json={"username": "owner", "password": "owner-password-123"},
+    )
+    app_settings = canonical_app.state.settings
+    workspace = app_settings.data_dir / "imports" / "app-owned-workspace"
+    workspace.mkdir(parents=True)
+    (workspace / "story.yaml").write_text("title: App-owned import\n", encoding="utf-8")
+    monkeypatch.setenv("APP_DATA_DIR", str(tmp_path / "global-data"))
+    reset_settings()
+
+    preview = canonical_client.post(
+        "/api/imports/preview",
+        json={"source": workspace.name},
+    )
+
+    assert preview.status_code == 200
+    assert preview.json()["title"] == "App-owned import"
+
+
+def test_runtime_provider_factory_uses_explicit_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("APP_ENVIRONMENT", "testing")
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    reset_settings()
+    settings = NovelEngineSettings(
+        environment="testing",
+        data_dir=tmp_path,
+        database=DatabaseSettings(url=f"sqlite:///{tmp_path / 'studio.sqlite3'}"),
+        llm=LLMSettings(
+            provider="dashscope",
+            DASHSCOPE_API_KEY="explicit-dashscope-key",
+            DASHSCOPE_MODEL="explicit-model",
+        ),
+    )
+    runtime = create_runtime(settings)
+
+    try:
+        provider = runtime.store.ai_service._ai_provider_factory(
+            "dashscope", "explicit-model"
+        )
+    finally:
+        runtime.database.dispose()
+
+    assert isinstance(provider, DashScopeTextGenerationProvider)
+
+
+def test_ai_proposal_route_uses_app_owned_model_after_global_settings_change(
+    canonical_app: FastAPI,
+    canonical_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical_client.post("/api/session/guest")
+    project = canonical_client.post(
+        "/api/projects", json={"title": "Settings-owned AI"}
+    ).json()
+    document = project["documents"][0]
+    app_model = canonical_app.state.settings.llm.resolved_model("mock")
+    monkeypatch.setenv("LLM_MODEL", "global-model-after-app-start")
+    reset_settings()
+
+    proposal = canonical_client.post(
+        f"/api/projects/{project['id']}/documents/{document['id']}/ai-proposals",
+        json={
+            "operation": "continue",
+            "instruction": "Continue from here.",
+            "provider": "mock",
+        },
+    )
+
+    assert proposal.status_code == 200
+    assert proposal.json()["model"] == app_model
+
+    providers = canonical_client.get("/api/providers")
+    assert providers.status_code == 200
+    mock_provider = next(
+        item for item in providers.json()["providers"] if item["provider"] == "mock"
+    )
+    assert mock_provider["model"] == app_model

--- a/tests/shared/infrastructure/rate_limit/test_token_bucket.py
+++ b/tests/shared/infrastructure/rate_limit/test_token_bucket.py
@@ -108,6 +108,8 @@ async def test_token_bucket_cleans_up_expired_keys() -> None:
     assert "b" not in limiter._tokens
     assert "a" not in limiter._last_update
     assert "b" not in limiter._last_update
+    assert "a" not in limiter._locks
+    assert "b" not in limiter._locks
 
 
 async def test_token_bucket_keeps_active_keys_during_cleanup() -> None:

--- a/tests/unit/contexts/studio/application/test_ai_service.py
+++ b/tests/unit/contexts/studio/application/test_ai_service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import cast
 
+import pytest
+
 from src.contexts.ai.application.ports.text_generation_port import (
     TextGenerationProvider,
     TextGenerationProviderError,
@@ -15,7 +17,7 @@ from src.contexts.ai.application.ports.text_generation_port import (
 from src.contexts.studio.application.ports.ai_provider import (
     TextGenerationProviderFactory,
 )
-from src.contexts.studio.application.service_common import Principal
+from src.contexts.studio.application.service_common import InvalidOperation, Principal
 from src.contexts.studio.application.services.ai_service import AIService
 from src.contexts.studio.application.services.project_service import ProjectService
 from tests.fakes.fake_studio_repository import FakeStudioRepository
@@ -123,6 +125,38 @@ async def test_create_ai_proposal_persists_failed_job_on_provider_error(
     assert result["status"] == "failed"
     assert result["error"] == "provider failure"
     assert result["result"]["proposal_markdown"] == ""
+
+
+async def test_accept_ai_proposal_rejects_failed_job_without_changing_document(
+    fake_repository: FakeStudioRepository,
+) -> None:
+    principal = _guest("guest-session-1")
+    project = ProjectService(fake_repository).create_project(
+        principal, title="AI Failure Accept Test"
+    )
+    document = project["documents"][0]
+    service = AIService(
+        fake_repository, cast(TextGenerationProviderFactory, _failing_provider_factory)
+    )
+    failed = await service.create_ai_proposal(
+        principal,
+        project["id"],
+        document["id"],
+        operation="continue",
+        instruction="Make it longer.",
+    )
+
+    with pytest.raises(InvalidOperation, match="completed proposal"):
+        service.accept_ai_proposal(principal, project["id"], failed["id"])
+
+    current = fake_repository.get_document(
+        project["id"],
+        document["id"],
+        owner_id=None,
+        guest_session_id=principal.session_id,
+    )
+    assert current.current_revision is not None
+    assert current.current_revision.content_markdown == document["content_markdown"]
 
 
 async def test_generate_proposal_returns_proposal_and_base_revision(


### PR DESCRIPTION
## Summary

Hardens the Novel Studio runtime and API contract paths found during the quality review:

- Rejects failed or contentless AI proposal jobs before accepting them into documents.
- Keeps API runtime/request settings bound to the active FastAPI app state instead of later global settings changes.
- Cleans expired token-bucket lock entries alongside token/update state.
- Replaces unchecked frontend success-response casts with runtime API response parsers.
- Adds app-owned settings regression coverage and updates OpenSpec/CHANGELOG for the behavior change.

## Why

The review found several correctness and design risks: failed AI proposal jobs could be accepted, some live request paths could drift to global settings instead of the app-owned runtime, rate limiter locks could accumulate after cleanup, and the frontend API client trusted JSON payloads through generic casts.

## Validation

- `uv run pytest -q`
- `uv run mypy src tests`
- `uv run ruff format --check src tests scripts`
- `uv run ruff check src tests`
- `uv run lint-imports`
- `uv run bandit -r src`
- `uv run python scripts/qa/check_file_sizes.py`
- `uv run python scripts/qa/check_openapi_snapshot.py`
- `uv run python scripts/qa/check_ssot.py`
- `uv run python scripts/qa/check_repo_hygiene.py`
- `corepack pnpm --dir frontend lint`
- `corepack pnpm --dir frontend format:check`
- `corepack pnpm --dir frontend type-check`
- `corepack pnpm --dir frontend test:unit`
- `corepack pnpm --dir frontend build`
- `corepack pnpm spec:validate`
- `corepack pnpm --dir frontend test:e2e:smoke`

## Notes

- No dependencies were added.
- OpenAPI snapshot remains current.
- OpenSpec now records rejection of invalid AI proposal acceptance.